### PR TITLE
feat: extend event schema and add stdin stream contract

### DIFF
--- a/.tickets/yr-1f3z.md
+++ b/.tickets/yr-1f3z.md
@@ -27,3 +27,7 @@ auto-reset after stalled runner_started with no progress >30m
 **2026-02-10T00:58:53Z**
 
 auto-reset after stalled run at 00:41Z; process killed
+
+**2026-02-10T01:45:04Z**
+
+auto-reset: ACP session reached idle but runner did not emit completion

--- a/.tickets/yr-1n7i.md
+++ b/.tickets/yr-1n7i.md
@@ -1,0 +1,19 @@
+---
+id: yr-1n7i
+status: open
+deps: [yr-kruo, yr-qua2]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T10 Add yolo-tui --events-stdin real-time consumer
+
+STRICT TDD: failing tests first. Consume stdin NDJSON incrementally and render live status/heartbeat/output panes.
+
+## Acceptance Criteria
+
+Given piped events from agent stdout, when tui runs with --events-stdin, then UI updates continuously without reading event files.
+

--- a/.tickets/yr-51b1.md
+++ b/.tickets/yr-51b1.md
@@ -1,0 +1,19 @@
+---
+id: yr-51b1
+status: open
+deps: [yr-tilv]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 1
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T11 Heartbeat and no-output stall indicators
+
+STRICT TDD: failing tests first. Emit runner_heartbeat and stale-output warnings on schedule with configurable thresholds.
+
+## Acceptance Criteria
+
+Given long-running tasks, when no output interval exceeds threshold, then stream and tui show heartbeat and stall warnings.
+

--- a/.tickets/yr-a0vs.md
+++ b/.tickets/yr-a0vs.md
@@ -1,0 +1,19 @@
+---
+id: yr-a0vs
+status: open
+deps: [yr-kruo]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T7 Forward ACP live updates via in-memory event callbacks
+
+STRICT TDD: failing tests first. Wire runner ACP updates to structured live events through callbacks/channels instead of log file tailing.
+
+## Acceptance Criteria
+
+Given active ACP session, when updates arrive, then agent receives structured progress events immediately without reading files.
+

--- a/.tickets/yr-c5hx.md
+++ b/.tickets/yr-c5hx.md
@@ -1,6 +1,6 @@
 ---
 id: yr-c5hx
-status: open
+status: closed
 deps: [yr-dsr0, yr-hxps]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/.tickets/yr-kruo.md
+++ b/.tickets/yr-kruo.md
@@ -1,0 +1,19 @@
+---
+id: yr-kruo
+status: closed
+deps: [yr-c5hx]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T6 Define live stream transport contract (stdout->stdin)
+
+STRICT TDD: failing tests first. Define NDJSON event stream contract for yolo-agent stdout and yolo-tui stdin with clear framing, ordering, and backward compatibility.
+
+## Acceptance Criteria
+
+Given streamed events, when parsed by tui, then events decode incrementally from stdin without logfile dependency.
+

--- a/.tickets/yr-l6cy.md
+++ b/.tickets/yr-l6cy.md
@@ -1,0 +1,19 @@
+---
+id: yr-l6cy
+status: open
+deps: [yr-1n7i, yr-51b1, yr-l745]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T13 End-to-end pipe smoke test (agent|tui)
+
+STRICT TDD: create failing e2e first. Verify live pipeline via command piping: yolo-agent --stream | yolo-tui --events-stdin.
+
+## Acceptance Criteria
+
+Given pipe mode, when one task runs, then tui shows live task/runner progress and completion without logfile reads.
+

--- a/.tickets/yr-l745.md
+++ b/.tickets/yr-l745.md
@@ -1,0 +1,19 @@
+---
+id: yr-l745
+status: open
+deps: [yr-tilv, yr-qua2]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 1
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T14 Backpressure and output-rate controls
+
+STRICT TDD: failing tests first. Add bounded queues, drop/coalesce policy for high-volume output, and --verbose-stream switch.
+
+## Acceptance Criteria
+
+Given high output volume, when streaming, then agent remains responsive and stream remains parseable with documented rate behavior.
+

--- a/.tickets/yr-nhop.md
+++ b/.tickets/yr-nhop.md
@@ -1,0 +1,19 @@
+---
+id: yr-nhop
+status: open
+deps: [yr-qua2]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 1
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T12 Add optional event file mirror (secondary sink)
+
+STRICT TDD: failing tests first. Keep file sink as optional mirror only, never primary transport for liveness.
+
+## Acceptance Criteria
+
+Given stream mode with file mirror enabled, when events flow, then stdout->stdin path remains primary and file mirror receives same events.
+

--- a/.tickets/yr-qua2.md
+++ b/.tickets/yr-qua2.md
@@ -1,0 +1,19 @@
+---
+id: yr-qua2
+status: open
+deps: [yr-kruo, yr-tilv]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T9 Add yolo-agent --stream mode (JSON stdout, human stderr)
+
+STRICT TDD: failing tests first. Add stream mode where stdout is NDJSON events only; diagnostics remain on stderr.
+
+## Acceptance Criteria
+
+Given --stream mode, when agent runs, then stdout contains valid NDJSON only and stderr keeps human diagnostics.
+

--- a/.tickets/yr-tilv.md
+++ b/.tickets/yr-tilv.md
@@ -1,0 +1,19 @@
+---
+id: yr-tilv
+status: open
+deps: [yr-a0vs]
+links: []
+created: 2026-02-10T01:46:34Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-T8 Emit command lifecycle and output events from agent
+
+STRICT TDD: failing tests first. Emit runner_cmd_started/finished, runner_output, and runner_warning events with bounded payloads and redaction.
+
+## Acceptance Criteria
+
+Given task execution, when commands run, then event stream includes start/finish metadata and recent output snippets in near real time.
+

--- a/cmd/yolo-tui/main_test.go
+++ b/cmd/yolo-tui/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/anomalyco/yolo-runner/internal/contracts"
 )
 
 func TestRunMainRendersMonitorViewFromEventsFile(t *testing.T) {
@@ -24,6 +27,46 @@ func TestRunMainRendersMonitorViewFromEventsFile(t *testing.T) {
 	}
 	if out.String() == "" {
 		t.Fatalf("expected rendered view")
+	}
+	if !contains(out.String(), "Current Task: task-1 - Readable task") {
+		t.Fatalf("expected current task in output, got %q", out.String())
+	}
+}
+
+func TestParseEventIncludesParallelContext(t *testing.T) {
+	line := []byte(`{"type":"runner_started","task_id":"task-1","task_title":"Readable task","worker_id":"worker-1","clone_path":"/tmp/clones/task-1","queue_pos":2,"message":"implement","ts":"2026-02-10T12:00:05Z"}`)
+
+	event, err := contracts.ParseEventJSONLLine(line)
+	if err != nil {
+		t.Fatalf("parse event failed: %v", err)
+	}
+	if event.WorkerID != "worker-1" {
+		t.Fatalf("expected worker id, got %q", event.WorkerID)
+	}
+	if event.ClonePath != "/tmp/clones/task-1" {
+		t.Fatalf("expected clone path, got %q", event.ClonePath)
+	}
+	if event.QueuePos != 2 {
+		t.Fatalf("expected queue pos 2, got %d", event.QueuePos)
+	}
+}
+
+func TestRenderFromReaderParsesIncrementalEvents(t *testing.T) {
+	reader, writer := io.Pipe()
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- renderFromReader(reader, out, errOut)
+	}()
+
+	_, _ = writer.Write([]byte("{\"type\":\"task_started\",\"task_id\":\"task-1\",\"task_title\":\"Readable task\",\"ts\":\"2026-02-10T12:00:00Z\"}\n"))
+	_, _ = writer.Write([]byte("{\"type\":\"runner_started\",\"task_id\":\"task-1\",\"worker_id\":\"worker-1\",\"queue_pos\":1,\"ts\":\"2026-02-10T12:00:01Z\"}\n"))
+	_ = writer.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("render from reader failed: %v", err)
 	}
 	if !contains(out.String(), "Current Task: task-1 - Readable task") {
 		t.Fatalf("expected current task in output, got %q", out.String())

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -121,6 +121,9 @@ type Event struct {
 	Type      EventType
 	TaskID    string
 	TaskTitle string
+	WorkerID  string
+	ClonePath string
+	QueuePos  int
 	Message   string
 	Metadata  map[string]string
 	Timestamp time.Time
@@ -131,6 +134,9 @@ func MarshalEventJSONL(event Event) (string, error) {
 		Type      EventType         `json:"type"`
 		TaskID    string            `json:"task_id"`
 		TaskTitle string            `json:"task_title,omitempty"`
+		WorkerID  string            `json:"worker_id,omitempty"`
+		ClonePath string            `json:"clone_path,omitempty"`
+		QueuePos  int               `json:"queue_pos,omitempty"`
 		Message   string            `json:"message,omitempty"`
 		Metadata  map[string]string `json:"metadata,omitempty"`
 		TS        string            `json:"ts"`
@@ -138,6 +144,9 @@ func MarshalEventJSONL(event Event) (string, error) {
 		Type:      event.Type,
 		TaskID:    event.TaskID,
 		TaskTitle: event.TaskTitle,
+		WorkerID:  event.WorkerID,
+		ClonePath: event.ClonePath,
+		QueuePos:  event.QueuePos,
 		Message:   event.Message,
 		Metadata:  event.Metadata,
 		TS:        event.Timestamp.UTC().Format(time.RFC3339),

--- a/internal/contracts/events_test.go
+++ b/internal/contracts/events_test.go
@@ -53,3 +53,24 @@ func TestMarshalEventJSONLIncludesTaskTitleWhenPresent(t *testing.T) {
 		t.Fatalf("unexpected json line\nexpected: %s\nactual:   %s", expected, strings.TrimSpace(line))
 	}
 }
+
+func TestMarshalEventJSONLIncludesParallelContextWhenPresent(t *testing.T) {
+	e := Event{
+		Type:      EventTypeRunnerStarted,
+		TaskID:    "task-9",
+		TaskTitle: "Parallel execution",
+		WorkerID:  "worker-2",
+		ClonePath: "/tmp/clones/task-9",
+		QueuePos:  3,
+		Timestamp: time.Date(2026, 2, 10, 13, 5, 0, 0, time.UTC),
+	}
+
+	line, err := MarshalEventJSONL(e)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	expected := `{"type":"runner_started","task_id":"task-9","task_title":"Parallel execution","worker_id":"worker-2","clone_path":"/tmp/clones/task-9","queue_pos":3,"ts":"2026-02-10T13:05:00Z"}`
+	if strings.TrimSpace(line) != expected {
+		t.Fatalf("unexpected json line\nexpected: %s\nactual:   %s", expected, strings.TrimSpace(line))
+	}
+}

--- a/internal/contracts/stream.go
+++ b/internal/contracts/stream.go
@@ -1,0 +1,88 @@
+package contracts
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type EventStream struct {
+	w io.Writer
+}
+
+func NewEventStream(writer io.Writer) *EventStream {
+	return &EventStream{w: writer}
+}
+
+func (s *EventStream) Write(event Event) error {
+	if s == nil || s.w == nil {
+		return nil
+	}
+	line, err := MarshalEventJSONL(event)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(s.w, line)
+	return err
+}
+
+type EventDecoder struct {
+	scanner *bufio.Scanner
+}
+
+func NewEventDecoder(reader io.Reader) *EventDecoder {
+	if reader == nil {
+		return &EventDecoder{}
+	}
+	return &EventDecoder{scanner: bufio.NewScanner(reader)}
+}
+
+func (d *EventDecoder) Next() (Event, error) {
+	if d == nil || d.scanner == nil {
+		return Event{}, io.EOF
+	}
+	if !d.scanner.Scan() {
+		if err := d.scanner.Err(); err != nil {
+			return Event{}, err
+		}
+		return Event{}, io.EOF
+	}
+	return ParseEventJSONLLine(d.scanner.Bytes())
+}
+
+func ParseEventJSONLLine(line []byte) (Event, error) {
+	var payload struct {
+		Type      string            `json:"type"`
+		TaskID    string            `json:"task_id"`
+		TaskTitle string            `json:"task_title"`
+		WorkerID  string            `json:"worker_id"`
+		ClonePath string            `json:"clone_path"`
+		QueuePos  int               `json:"queue_pos"`
+		Message   string            `json:"message"`
+		Metadata  map[string]string `json:"metadata"`
+		TS        string            `json:"ts"`
+	}
+	if err := json.Unmarshal(line, &payload); err != nil {
+		return Event{}, err
+	}
+	timestamp := time.Time{}
+	if payload.TS != "" {
+		parsed, err := time.Parse(time.RFC3339, payload.TS)
+		if err != nil {
+			return Event{}, err
+		}
+		timestamp = parsed
+	}
+	return Event{
+		Type:      EventType(payload.Type),
+		TaskID:    payload.TaskID,
+		TaskTitle: payload.TaskTitle,
+		WorkerID:  payload.WorkerID,
+		ClonePath: payload.ClonePath,
+		QueuePos:  payload.QueuePos,
+		Message:   payload.Message,
+		Metadata:  payload.Metadata,
+		Timestamp: timestamp,
+	}, nil
+}

--- a/internal/contracts/stream_test.go
+++ b/internal/contracts/stream_test.go
@@ -1,0 +1,37 @@
+package contracts
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestEventStreamRoundTripNDJSON(t *testing.T) {
+	buf := &bytes.Buffer{}
+	stream := NewEventStream(buf)
+
+	event := Event{
+		Type:      EventTypeRunnerStarted,
+		TaskID:    "task-1",
+		TaskTitle: "Streaming",
+		WorkerID:  "worker-1",
+		QueuePos:  1,
+		Timestamp: time.Date(2026, 2, 10, 2, 0, 0, 0, time.UTC),
+	}
+	if err := stream.Write(event); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	decoder := NewEventDecoder(bytes.NewReader(buf.Bytes()))
+	decoded, err := decoder.Next()
+	if err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if decoded.TaskID != event.TaskID || decoded.WorkerID != event.WorkerID || decoded.QueuePos != event.QueuePos {
+		t.Fatalf("unexpected decoded event: %#v", decoded)
+	}
+	if _, err := decoder.Next(); err != io.EOF {
+		t.Fatalf("expected EOF after one event, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend contracts event schema with parallel context (`worker_id`, `clone_path`, `queue_pos`) and propagate these fields from the agent loop
- add shared NDJSON stream primitives (`EventStream`, `EventDecoder`, `ParseEventJSONLLine`) to establish stdout->stdin transport contract
- refactor `yolo-tui` rendering to parse incrementally from a reader, enabling stream consumption groundwork without logfile coupling
- update E7 roadmap tickets and close E7-T1 (`yr-c5hx`) + E7-T6 (`yr-kruo`)

## Verification
- go test ./internal/contracts ./cmd/yolo-tui ./internal/agent
- go test ./...