### PR TITLE
feat: stream ACP updates via in-memory progress callbacks

### DIFF
--- a/.tickets/yr-a0vs.md
+++ b/.tickets/yr-a0vs.md
@@ -1,6 +1,6 @@
 ---
 id: yr-a0vs
-status: open
+status: closed
 deps: [yr-kruo]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -246,6 +246,19 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			Model:    l.options.Model,
 			Timeout:  l.options.RunnerTimeout,
 			Prompt:   buildPrompt(task, contracts.RunnerModeImplement),
+			OnProgress: func(progress contracts.RunnerProgress) {
+				_ = l.emit(ctx, contracts.Event{
+					Type:      contracts.EventTypeRunnerProgress,
+					TaskID:    task.ID,
+					TaskTitle: task.Title,
+					WorkerID:  worker,
+					ClonePath: taskRepoRoot,
+					QueuePos:  queuePos,
+					Message:   progress.Message,
+					Metadata:  progress.Metadata,
+					Timestamp: progress.Timestamp,
+				})
+			},
 		})
 		if err != nil {
 			return summary, err
@@ -262,6 +275,19 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 				Model:    l.options.Model,
 				Timeout:  l.options.RunnerTimeout,
 				Prompt:   buildPrompt(task, contracts.RunnerModeReview),
+				OnProgress: func(progress contracts.RunnerProgress) {
+					_ = l.emit(ctx, contracts.Event{
+						Type:      contracts.EventTypeRunnerProgress,
+						TaskID:    task.ID,
+						TaskTitle: task.Title,
+						WorkerID:  worker,
+						ClonePath: taskRepoRoot,
+						QueuePos:  queuePos,
+						Message:   progress.Message,
+						Metadata:  progress.Metadata,
+						Timestamp: progress.Timestamp,
+					})
+				},
 			})
 			if reviewErr != nil {
 				return summary, reviewErr

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -47,14 +47,22 @@ const (
 )
 
 type RunnerRequest struct {
-	TaskID   string
-	ParentID string
-	Prompt   string
-	Mode     RunnerMode
-	Model    string
-	RepoRoot string
-	Timeout  time.Duration
-	Metadata map[string]string
+	TaskID     string
+	ParentID   string
+	Prompt     string
+	Mode       RunnerMode
+	Model      string
+	RepoRoot   string
+	Timeout    time.Duration
+	Metadata   map[string]string
+	OnProgress func(RunnerProgress)
+}
+
+type RunnerProgress struct {
+	Type      string
+	Message   string
+	Metadata  map[string]string
+	Timestamp time.Time
 }
 
 type RunnerResultStatus string
@@ -108,6 +116,7 @@ const (
 	EventTypeTaskFinished    EventType = "task_finished"
 	EventTypeRunnerStarted   EventType = "runner_started"
 	EventTypeRunnerFinished  EventType = "runner_finished"
+	EventTypeRunnerProgress  EventType = "runner_progress"
 	EventTypeReviewStarted   EventType = "review_started"
 	EventTypeReviewFinished  EventType = "review_finished"
 	EventTypeBranchCreated   EventType = "branch_created"

--- a/internal/opencode/client.go
+++ b/internal/opencode/client.go
@@ -119,6 +119,10 @@ func RunWithContext(ctx context.Context, issueID string, repoRoot string, prompt
 }
 
 func RunWithACP(ctx context.Context, issueID string, repoRoot string, prompt string, model string, configRoot string, configDir string, logPath string, runner Runner, acpClient ACPClient) error {
+	return RunWithACPAndUpdates(ctx, issueID, repoRoot, prompt, model, configRoot, configDir, logPath, runner, acpClient, nil)
+}
+
+func RunWithACPAndUpdates(ctx context.Context, issueID string, repoRoot string, prompt string, model string, configRoot string, configDir string, logPath string, runner Runner, acpClient ACPClient, onLineUpdate func(string)) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -181,6 +185,9 @@ func RunWithACP(ctx context.Context, issueID string, repoRoot string, prompt str
 					return
 				}
 				if line := aggregator.ProcessUpdate(&note.Update); line != "" {
+					if onLineUpdate != nil {
+						onLineUpdate(line)
+					}
 					// Skip writing tool calls directly to console - they should go to log bubble instead
 					// Only write non-tool-call messages to console
 					if !strings.HasPrefix(line, "⏳") && !strings.HasPrefix(line, "🔄") && !strings.HasPrefix(line, "✅") && !strings.HasPrefix(line, "❌") && !strings.HasPrefix(line, "⚪") {


### PR DESCRIPTION
## Summary
- add runner progress callback plumbing to the contracts runner request model
- wire OpenCode ACP update lines through `RunWithACPAndUpdates` into `CLIRunnerAdapter` progress callbacks
- forward runner progress callbacks from agent loop into `runner_progress` events with task/worker/clone context
- close E7-T7 (`yr-a0vs`) after strict TDD validation

## Verification
- go test ./internal/opencode ./internal/agent -run 'ForwardsACPUpdatesToProgressCallback|RunnerProgressEventsFromRunnerCallback'
- go test ./...