### PR TITLE
feat: emit command lifecycle and output stream events

### DIFF
--- a/.tickets/yr-tilv.md
+++ b/.tickets/yr-tilv.md
@@ -1,6 +1,6 @@
 ---
 id: yr-tilv
-status: open
+status: closed
 deps: [yr-a0vs]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -248,7 +248,7 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			Prompt:   buildPrompt(task, contracts.RunnerModeImplement),
 			OnProgress: func(progress contracts.RunnerProgress) {
 				_ = l.emit(ctx, contracts.Event{
-					Type:      contracts.EventTypeRunnerProgress,
+					Type:      eventTypeForRunnerProgress(progress.Type),
 					TaskID:    task.ID,
 					TaskTitle: task.Title,
 					WorkerID:  worker,
@@ -277,7 +277,7 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 				Prompt:   buildPrompt(task, contracts.RunnerModeReview),
 				OnProgress: func(progress contracts.RunnerProgress) {
 					_ = l.emit(ctx, contracts.Event{
-						Type:      contracts.EventTypeRunnerProgress,
+						Type:      eventTypeForRunnerProgress(progress.Type),
 						TaskID:    task.ID,
 						TaskTitle: task.Title,
 						WorkerID:  worker,
@@ -393,6 +393,21 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			summary.Failed++
 			return summary, nil
 		}
+	}
+}
+
+func eventTypeForRunnerProgress(progressType string) contracts.EventType {
+	switch strings.TrimSpace(progressType) {
+	case "runner_cmd_started":
+		return contracts.EventTypeRunnerCommandStarted
+	case "runner_cmd_finished":
+		return contracts.EventTypeRunnerCommandFinished
+	case "runner_output":
+		return contracts.EventTypeRunnerOutput
+	case "runner_warning":
+		return contracts.EventTypeRunnerWarning
+	default:
+		return contracts.EventTypeRunnerProgress
 	}
 }
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -112,18 +112,22 @@ func (s LoopSummary) TotalProcessed() int {
 type EventType string
 
 const (
-	EventTypeTaskStarted     EventType = "task_started"
-	EventTypeTaskFinished    EventType = "task_finished"
-	EventTypeRunnerStarted   EventType = "runner_started"
-	EventTypeRunnerFinished  EventType = "runner_finished"
-	EventTypeRunnerProgress  EventType = "runner_progress"
-	EventTypeReviewStarted   EventType = "review_started"
-	EventTypeReviewFinished  EventType = "review_finished"
-	EventTypeBranchCreated   EventType = "branch_created"
-	EventTypeMergeCompleted  EventType = "merge_completed"
-	EventTypePushCompleted   EventType = "push_completed"
-	EventTypeTaskStatusSet   EventType = "task_status_set"
-	EventTypeTaskDataUpdated EventType = "task_data_updated"
+	EventTypeTaskStarted           EventType = "task_started"
+	EventTypeTaskFinished          EventType = "task_finished"
+	EventTypeRunnerStarted         EventType = "runner_started"
+	EventTypeRunnerFinished        EventType = "runner_finished"
+	EventTypeRunnerProgress        EventType = "runner_progress"
+	EventTypeRunnerCommandStarted  EventType = "runner_cmd_started"
+	EventTypeRunnerCommandFinished EventType = "runner_cmd_finished"
+	EventTypeRunnerOutput          EventType = "runner_output"
+	EventTypeRunnerWarning         EventType = "runner_warning"
+	EventTypeReviewStarted         EventType = "review_started"
+	EventTypeReviewFinished        EventType = "review_finished"
+	EventTypeBranchCreated         EventType = "branch_created"
+	EventTypeMergeCompleted        EventType = "merge_completed"
+	EventTypePushCompleted         EventType = "push_completed"
+	EventTypeTaskStatusSet         EventType = "task_status_set"
+	EventTypeTaskDataUpdated       EventType = "task_data_updated"
 )
 
 type Event struct {


### PR DESCRIPTION
## Summary
- classify ACP live updates into command lifecycle/output categories (`runner_cmd_started`, `runner_cmd_finished`, `runner_output`, `runner_warning`)
- redact and bound streamed ACP payloads before forwarding progress
- map runner progress categories into typed agent events for stream consumers
- close E7-T8 (`yr-tilv`) after strict TDD validation

## Verification
- go test ./internal/opencode ./internal/agent -run 'NormalizeACPUpdateLine|ForwardsACPUpdatesToProgressCallback|RunnerProgressEventsFromRunnerCallback'
- go test ./...