### PR TITLE
feat: add stream mode for agent stdout transport

### DIFF
--- a/.tickets/yr-qua2.md
+++ b/.tickets/yr-qua2.md
@@ -1,6 +1,6 @@
 ---
 id: yr-qua2
-status: open
+status: closed
 deps: [yr-kruo, yr-tilv]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/internal/contracts/file_sink_test.go
+++ b/internal/contracts/file_sink_test.go
@@ -30,3 +30,30 @@ func TestFileEventSinkWritesJSONL(t *testing.T) {
 		t.Fatalf("expected task title in sink output, got %q", string(content))
 	}
 }
+
+func TestStreamEventSinkWritesToWriterAsNDJSON(t *testing.T) {
+	buf := &strings.Builder{}
+	sink := NewStreamEventSink(buf)
+
+	err := sink.Emit(context.Background(), Event{Type: EventTypeRunnerStarted, TaskID: "task-2", TaskTitle: "Streaming", Timestamp: time.Date(2026, 2, 10, 14, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("emit failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"type":"runner_started"`) {
+		t.Fatalf("expected runner_started in stream output, got %q", buf.String())
+	}
+}
+
+func TestFanoutEventSinkBroadcastsToAllSinks(t *testing.T) {
+	left := &strings.Builder{}
+	right := &strings.Builder{}
+	sink := NewFanoutEventSink(NewStreamEventSink(left), NewStreamEventSink(right))
+
+	err := sink.Emit(context.Background(), Event{Type: EventTypeTaskStarted, TaskID: "task-3", Timestamp: time.Date(2026, 2, 10, 14, 5, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("emit failed: %v", err)
+	}
+	if !strings.Contains(left.String(), `"task_id":"task-3"`) || !strings.Contains(right.String(), `"task_id":"task-3"`) {
+		t.Fatalf("expected both sinks to receive event, got left=%q right=%q", left.String(), right.String())
+	}
+}

--- a/internal/contracts/stream_sink.go
+++ b/internal/contracts/stream_sink.go
@@ -1,0 +1,55 @@
+package contracts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+type StreamEventSink struct {
+	stream *EventStream
+	mu     sync.Mutex
+}
+
+func NewStreamEventSink(writer io.Writer) *StreamEventSink {
+	return &StreamEventSink{stream: NewEventStream(writer)}
+}
+
+func (s *StreamEventSink) Emit(_ context.Context, event Event) error {
+	if s == nil || s.stream == nil {
+		return nil
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stream.Write(event)
+}
+
+type FanoutEventSink struct {
+	sinks []EventSink
+}
+
+func NewFanoutEventSink(sinks ...EventSink) *FanoutEventSink {
+	filtered := make([]EventSink, 0, len(sinks))
+	for _, sink := range sinks {
+		if sink != nil {
+			filtered = append(filtered, sink)
+		}
+	}
+	return &FanoutEventSink{sinks: filtered}
+}
+
+func (f *FanoutEventSink) Emit(ctx context.Context, event Event) error {
+	if f == nil {
+		return nil
+	}
+	var err error
+	for _, sink := range f.sinks {
+		err = errors.Join(err, sink.Emit(ctx, event))
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- add `--stream` mode in `yolo-agent` to emit NDJSON events to stdout while keeping human diagnostics on stderr
- add stream/file sink fanout support with optional file mirror behavior
- add tests for stream flag parsing, default events path resolution in stream mode, and NDJSON emission contract
- close E7-T9 (`yr-qua2`)

## Verification
- go test ./cmd/yolo-agent -run 'ParsesStreamFlag|ResolveEventsPath|RunWithComponentsStreamWritesNDJSONToStdout'
- go test ./internal/contracts ./cmd/yolo-agent
- go test ./...