### PR TITLE
feat: switch yolo-tui to stdin-only streaming mode

### DIFF
--- a/.tickets/yr-1n7i.md
+++ b/.tickets/yr-1n7i.md
@@ -1,6 +1,6 @@
 ---
 id: yr-1n7i
-status: open
+status: closed
 deps: [yr-kruo, yr-qua2]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,7 +18,7 @@
   - `yolo-task data --id <task> --set key=value`
 
 - Old TUI behavior in `yolo-runner`
-- New read-only monitor: `yolo-tui --events runner-logs/agent.events.jsonl`
+- New read-only monitor: `yolo-agent --stream ... | yolo-tui --events-stdin`
 
 ## Compatibility Behavior
 


### PR DESCRIPTION
## Summary
- make `yolo-tui` consume NDJSON events from stdin as the only input mode
- add `--events-stdin` support (enabled by default) and remove file-path operation from runtime flow
- render incrementally on each incoming event for live updates
- update migration docs and close E7-T10 (`yr-1n7i`)

## Verification
- go test ./cmd/yolo-tui
- go test ./internal/contracts ./cmd/yolo-agent ./cmd/yolo-tui
- go test ./...