### PR TITLE
feat: add runner heartbeat and no-output warning events

### DIFF
--- a/.tickets/yr-51b1.md
+++ b/.tickets/yr-51b1.md
@@ -1,6 +1,6 @@
 ---
 id: yr-51b1
-status: open
+status: closed
 deps: [yr-tilv]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -117,6 +117,7 @@ const (
 	EventTypeRunnerStarted         EventType = "runner_started"
 	EventTypeRunnerFinished        EventType = "runner_finished"
 	EventTypeRunnerProgress        EventType = "runner_progress"
+	EventTypeRunnerHeartbeat       EventType = "runner_heartbeat"
 	EventTypeRunnerCommandStarted  EventType = "runner_cmd_started"
 	EventTypeRunnerCommandFinished EventType = "runner_cmd_finished"
 	EventTypeRunnerOutput          EventType = "runner_output"


### PR DESCRIPTION
## Summary
- add periodic `runner_heartbeat` events while runner execution is active
- emit `runner_warning` when no-output threshold is exceeded during long runs
- preserve task/worker/clone context on heartbeat/warning events for stream consumers
- close E7-T11 (`yr-51b1`) with strict TDD coverage

## Verification
- go test ./internal/agent -run 'RunnerHeartbeat|NoOutputThresholdExceeded|RunnerProgressEventsFromRunnerCallback'
- go test ./...