### PR TITLE
feat: add stream output backpressure controls

### DIFF
--- a/.tickets/yr-l745.md
+++ b/.tickets/yr-l745.md
@@ -1,6 +1,6 @@
 ---
 id: yr-l745
-status: open
+status: in_progress
 deps: [yr-tilv, yr-qua2]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,3 +23,13 @@
 ## Compatibility Behavior
 
 Invoking `yolo-runner` prints a compatibility notice and continues to run, so existing scripts are preserved while migration proceeds.
+
+## Stream Rate Controls
+
+`yolo-agent --stream` now applies output backpressure controls for `runner_output` events by default:
+
+- A bounded coalescing buffer retains up to `--stream-output-buffer` pending output events (default `64`).
+- If output arrives faster than `--stream-output-interval` (default `150ms`), intermediate lines are coalesced into the newest emitted line.
+- When the buffer overflows, older pending output lines are dropped; emitted events include `metadata.coalesced_outputs` and `metadata.dropped_outputs` counters.
+
+Use `--verbose-stream` to disable coalescing and emit every `runner_output` line.

--- a/internal/contracts/file_sink_test.go
+++ b/internal/contracts/file_sink_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,69 @@ func TestStreamEventSinkWritesToWriterAsNDJSON(t *testing.T) {
 	if !strings.Contains(buf.String(), `"type":"runner_started"`) {
 		t.Fatalf("expected runner_started in stream output, got %q", buf.String())
 	}
+}
+
+func TestStreamEventSinkCoalescesRunnerOutputByDefault(t *testing.T) {
+	buf := &strings.Builder{}
+	sink := NewStreamEventSinkWithOptions(buf, StreamEventSinkOptions{
+		OutputInterval: 10 * time.Second,
+		MaxPending:     2,
+	})
+
+	for i := 0; i < 4; i++ {
+		if err := sink.Emit(context.Background(), Event{Type: EventTypeRunnerOutput, TaskID: "task-2", Message: "line", Timestamp: time.Date(2026, 2, 10, 14, 0, i, 0, time.UTC)}); err != nil {
+			t.Fatalf("emit output %d failed: %v", i, err)
+		}
+	}
+	if err := sink.Emit(context.Background(), Event{Type: EventTypeRunnerFinished, TaskID: "task-2", Timestamp: time.Date(2026, 2, 10, 14, 1, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("emit runner_finished failed: %v", err)
+	}
+
+	lines := splitJSONLLines(buf.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected [first_output coalesced_output runner_finished], got %d lines: %q", len(lines), buf.String())
+	}
+
+	var payload struct {
+		Type     string            `json:"type"`
+		Metadata map[string]string `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &payload); err != nil {
+		t.Fatalf("decode coalesced payload: %v", err)
+	}
+	if payload.Type != string(EventTypeRunnerOutput) {
+		t.Fatalf("expected coalesced runner_output, got %q", payload.Type)
+	}
+	if payload.Metadata["coalesced_outputs"] != "1" {
+		t.Fatalf("expected coalesced_outputs=1, got %#v", payload.Metadata)
+	}
+	if payload.Metadata["dropped_outputs"] != "1" {
+		t.Fatalf("expected dropped_outputs=1, got %#v", payload.Metadata)
+	}
+}
+
+func TestStreamEventSinkVerboseModeDoesNotCoalesceOutput(t *testing.T) {
+	buf := &strings.Builder{}
+	sink := NewStreamEventSinkWithOptions(buf, StreamEventSinkOptions{VerboseOutput: true})
+
+	for i := 0; i < 3; i++ {
+		if err := sink.Emit(context.Background(), Event{Type: EventTypeRunnerOutput, TaskID: "task-3", Message: "line", Timestamp: time.Date(2026, 2, 10, 15, 0, i, 0, time.UTC)}); err != nil {
+			t.Fatalf("emit output %d failed: %v", i, err)
+		}
+	}
+
+	lines := splitJSONLLines(buf.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 output lines in verbose mode, got %d: %q", len(lines), buf.String())
+	}
+}
+
+func splitJSONLLines(content string) []string {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
 }
 
 func TestFanoutEventSinkBroadcastsToAllSinks(t *testing.T) {

--- a/internal/contracts/stream_sink.go
+++ b/internal/contracts/stream_sink.go
@@ -4,17 +4,48 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strconv"
 	"sync"
 	"time"
 )
 
 type StreamEventSink struct {
-	stream *EventStream
-	mu     sync.Mutex
+	stream         *EventStream
+	mu             sync.Mutex
+	verboseOutput  bool
+	outputInterval time.Duration
+	maxPending     int
+	lastOutputAt   time.Time
+	pendingOutput  *Event
+	pendingCount   int
+	droppedCount   int
 }
 
 func NewStreamEventSink(writer io.Writer) *StreamEventSink {
-	return &StreamEventSink{stream: NewEventStream(writer)}
+	return NewStreamEventSinkWithOptions(writer, StreamEventSinkOptions{})
+}
+
+type StreamEventSinkOptions struct {
+	VerboseOutput  bool
+	OutputInterval time.Duration
+	MaxPending     int
+}
+
+func NewStreamEventSinkWithOptions(writer io.Writer, options StreamEventSinkOptions) *StreamEventSink {
+	interval := options.OutputInterval
+	if interval <= 0 {
+		interval = 150 * time.Millisecond
+	}
+	maxPending := options.MaxPending
+	if maxPending <= 0 {
+		maxPending = 64
+	}
+	return &StreamEventSink{
+		stream:         NewEventStream(writer),
+		verboseOutput:  options.VerboseOutput,
+		outputInterval: interval,
+		maxPending:     maxPending,
+	}
 }
 
 func (s *StreamEventSink) Emit(_ context.Context, event Event) error {
@@ -26,6 +57,59 @@ func (s *StreamEventSink) Emit(_ context.Context, event Event) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.verboseOutput || event.Type != EventTypeRunnerOutput {
+		if err := s.flushPendingRunnerOutputLocked(); err != nil {
+			return err
+		}
+		if event.Type == EventTypeRunnerOutput {
+			s.lastOutputAt = event.Timestamp
+		}
+		return s.stream.Write(event)
+	}
+
+	now := event.Timestamp
+	if s.lastOutputAt.IsZero() || now.Sub(s.lastOutputAt) >= s.outputInterval {
+		if err := s.flushPendingRunnerOutputLocked(); err != nil {
+			return err
+		}
+		s.lastOutputAt = now
+		return s.stream.Write(event)
+	}
+
+	s.queueRunnerOutputLocked(event)
+	return nil
+}
+
+func (s *StreamEventSink) queueRunnerOutputLocked(event Event) {
+	eventCopy := event
+	s.pendingOutput = &eventCopy
+	if s.pendingCount < s.maxPending {
+		s.pendingCount++
+		return
+	}
+	s.droppedCount++
+}
+
+func (s *StreamEventSink) flushPendingRunnerOutputLocked() error {
+	if s.pendingOutput == nil {
+		return nil
+	}
+	event := *s.pendingOutput
+	if event.Metadata == nil {
+		event.Metadata = map[string]string{}
+	}
+	coalesced := s.pendingCount - 1
+	if coalesced > 0 {
+		event.Metadata["coalesced_outputs"] = strconv.Itoa(coalesced)
+	}
+	if s.droppedCount > 0 {
+		event.Metadata["dropped_outputs"] = strconv.Itoa(s.droppedCount)
+	}
+	s.pendingOutput = nil
+	s.pendingCount = 0
+	s.droppedCount = 0
+	s.lastOutputAt = event.Timestamp
 	return s.stream.Write(event)
 }
 


### PR DESCRIPTION
## Summary
- add configurable stream output controls to `yolo-agent` (`--verbose-stream`, `--stream-output-interval`, `--stream-output-buffer`) and validate their values
- implement bounded coalescing/drop behavior in `StreamEventSink` so high-volume `runner_output` events are rate-limited while preserving parseable NDJSON metadata counters
- add focused tests for default coalescing, verbose passthrough mode, and end-to-end CLI wiring; document stream-rate behavior in migration guidance

## Testing
- go test ./...