### PR TITLE
feat: make stream file mirror best-effort

### DIFF
--- a/.tickets/yr-l745.md
+++ b/.tickets/yr-l745.md
@@ -1,6 +1,6 @@
 ---
 id: yr-l745
-status: in_progress
+status: closed
 deps: [yr-tilv, yr-qua2]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/.tickets/yr-nhop.md
+++ b/.tickets/yr-nhop.md
@@ -1,6 +1,6 @@
 ---
 id: yr-nhop
-status: open
+status: in_progress
 deps: [yr-qua2]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,3 +33,5 @@ Invoking `yolo-runner` prints a compatibility notice and continues to run, so ex
 - When the buffer overflows, older pending output lines are dropped; emitted events include `metadata.coalesced_outputs` and `metadata.dropped_outputs` counters.
 
 Use `--verbose-stream` to disable coalescing and emit every `runner_output` line.
+
+When `--stream` and `--events <path>` are combined, the file sink runs as a best-effort mirror: stdout NDJSON remains primary, and mirror backpressure/errors do not block live stream delivery.


### PR DESCRIPTION
## Summary
- wrap stream-mode `--events` file sink in a non-blocking mirror sink so stdout NDJSON remains the primary transport under mirror backpressure/errors
- keep non-stream behavior unchanged while dropping mirror events when the mirror queue is full
- add tests covering stream resilience with mirror failures and non-blocking mirror queue behavior; document mirror semantics in migration notes

## Testing
- go test ./...