### PR TITLE
feat: add multi-worker and landing queue monitor views

### DIFF
--- a/.tickets/yr-37ot.md
+++ b/.tickets/yr-37ot.md
@@ -1,6 +1,6 @@
 ---
 id: yr-37ot
-status: open
+status: in_progress
 deps: [yr-c5hx]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/.tickets/yr-l6cy.md
+++ b/.tickets/yr-l6cy.md
@@ -1,6 +1,6 @@
 ---
 id: yr-l6cy
-status: in_progress
+status: closed
 deps: [yr-1n7i, yr-51b1, yr-l745]
 links: []
 created: 2026-02-10T01:46:34Z

--- a/internal/ui/monitor/model_test.go
+++ b/internal/ui/monitor/model_test.go
@@ -24,6 +24,32 @@ func TestModelTracksCurrentTaskPhaseAgeAndHistory(t *testing.T) {
 	assertContains(t, view, "runner finished")
 }
 
+func TestModelRendersWorkerLanesFromParallelContext(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 1, 0, 0, time.UTC)
+	model := NewModel(func() time.Time { return now })
+
+	model.Apply(contracts.Event{Type: contracts.EventTypeTaskStarted, TaskID: "task-1", TaskTitle: "First", WorkerID: "worker-1", QueuePos: 1, Timestamp: now.Add(-3 * time.Second)})
+	model.Apply(contracts.Event{Type: contracts.EventTypeRunnerStarted, TaskID: "task-2", TaskTitle: "Second", WorkerID: "worker-2", QueuePos: 2, Timestamp: now.Add(-2 * time.Second)})
+
+	view := model.View()
+	assertContains(t, view, "Workers:")
+	assertContains(t, view, "worker-1 => task-1 - First [task_started] (queue=1)")
+	assertContains(t, view, "worker-2 => task-2 - Second [runner_started] (queue=2)")
+}
+
+func TestModelRendersLandingQueueStatesFromTaskFinishedEvents(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 2, 0, 0, time.UTC)
+	model := NewModel(func() time.Time { return now })
+
+	model.Apply(contracts.Event{Type: contracts.EventTypeTaskFinished, TaskID: "task-1", TaskTitle: "First", Message: "closed", Timestamp: now.Add(-3 * time.Second)})
+	model.Apply(contracts.Event{Type: contracts.EventTypeTaskFinished, TaskID: "task-2", TaskTitle: "Second", Message: "failed", Timestamp: now.Add(-1 * time.Second)})
+
+	view := model.View()
+	assertContains(t, view, "Landing Queue:")
+	assertContains(t, view, "task-1 - First => closed")
+	assertContains(t, view, "task-2 - Second => failed")
+}
+
 func assertContains(t *testing.T, text string, expected string) {
 	t.Helper()
 	if !contains(text, expected) {


### PR DESCRIPTION
## Summary
- extend monitor model state to track active worker lanes from streamed parallel context (`worker_id`, `queue_pos`, task, phase)
- add landing queue state rendering derived from `task_finished` events so terminal task outcomes are visible in TUI output
- add failing-first model tests for worker lane and landing queue sections; update ticket state transitions for `yr-l6cy` and `yr-37ot`

## Testing
- go test ./internal/ui/monitor
- go test ./cmd/yolo-tui
- go test ./...