### PR TITLE
feat: normalize triage panel data in stream monitor

### DIFF
--- a/.tickets/yr-37ot.md
+++ b/.tickets/yr-37ot.md
@@ -1,6 +1,6 @@
 ---
 id: yr-37ot
-status: in_progress
+status: closed
 deps: [yr-c5hx]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/.tickets/yr-70la.md
+++ b/.tickets/yr-70la.md
@@ -1,6 +1,6 @@
 ---
 id: yr-70la
-status: open
+status: in_progress
 deps: [yr-37ot]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -320,6 +320,7 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			if err := l.tasks.SetTaskData(ctx, task.ID, blockedData); err != nil {
 				return summary, err
 			}
+			_ = l.emit(ctx, contracts.Event{Type: contracts.EventTypeTaskDataUpdated, TaskID: task.ID, TaskTitle: task.Title, WorkerID: worker, ClonePath: taskRepoRoot, QueuePos: queuePos, Metadata: blockedData, Timestamp: time.Now().UTC()})
 			if err := l.clearTaskTerminalState(task.ID); err != nil {
 				return summary, err
 			}
@@ -343,6 +344,7 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			if err := l.tasks.SetTaskData(ctx, task.ID, failedData); err != nil {
 				return summary, err
 			}
+			_ = l.emit(ctx, contracts.Event{Type: contracts.EventTypeTaskDataUpdated, TaskID: task.ID, TaskTitle: task.Title, WorkerID: worker, ClonePath: taskRepoRoot, QueuePos: queuePos, Metadata: failedData, Timestamp: time.Now().UTC()})
 			if err := l.tasks.SetTaskStatus(ctx, task.ID, contracts.TaskStatusFailed); err != nil {
 				return summary, err
 			}
@@ -360,6 +362,7 @@ func (l *Loop) runTask(ctx context.Context, taskID string, workerID int, queuePo
 			if err := l.tasks.SetTaskData(ctx, task.ID, failedData); err != nil {
 				return summary, err
 			}
+			_ = l.emit(ctx, contracts.Event{Type: contracts.EventTypeTaskDataUpdated, TaskID: task.ID, TaskTitle: task.Title, WorkerID: worker, ClonePath: taskRepoRoot, QueuePos: queuePos, Metadata: failedData, Timestamp: time.Now().UTC()})
 			if err := l.tasks.SetTaskStatus(ctx, task.ID, contracts.TaskStatusFailed); err != nil {
 				return summary, err
 			}

--- a/internal/ui/monitor/model_test.go
+++ b/internal/ui/monitor/model_test.go
@@ -50,6 +50,26 @@ func TestModelRendersLandingQueueStatesFromTaskFinishedEvents(t *testing.T) {
 	assertContains(t, view, "task-2 - Second => failed")
 }
 
+func TestModelNormalizesTriagePanelData(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 3, 0, 0, time.UTC)
+	model := NewModel(func() time.Time { return now })
+
+	model.Apply(contracts.Event{
+		Type:      contracts.EventTypeTaskDataUpdated,
+		TaskID:    "task-1",
+		TaskTitle: "First",
+		Metadata: map[string]string{
+			"triage_status": " Failed ",
+			"triage_reason": "  lint failed  ",
+		},
+		Timestamp: now.Add(-2 * time.Second),
+	})
+
+	view := model.View()
+	assertContains(t, view, "Triage:")
+	assertContains(t, view, "task-1 - First => failed | lint failed")
+}
+
 func assertContains(t *testing.T, text string, expected string) {
 	t.Helper()
 	if !contains(text, expected) {


### PR DESCRIPTION
## Summary
- emit `task_data_updated` events from the agent loop when blocked/failed triage metadata is written
- extend monitor model with a dedicated `Triage` section that normalizes `triage_status` and `triage_reason` per task
- add failing-first tests for triage event emission and UI normalization, plus ticket state transitions for `yr-37ot` and `yr-70la`

## Testing
- go test ./internal/agent -run TestLoopEmitsTaskDataUpdatedEventFor(Blocked|Failed)Triage
- go test ./internal/ui/monitor -run TestModelNormalizesTriagePanelData
- go test ./...