### PR TITLE
test: add multi-worker stream smoke coverage

### DIFF
--- a/.tickets/yr-20os.md
+++ b/.tickets/yr-20os.md
@@ -1,6 +1,6 @@
 ---
 id: yr-20os
-status: open
+status: in_progress
 deps: [yr-70la]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/.tickets/yr-70la.md
+++ b/.tickets/yr-70la.md
@@ -1,6 +1,6 @@
 ---
 id: yr-70la
-status: in_progress
+status: closed
 deps: [yr-37ot]
 links: []
 created: 2026-02-09T23:07:08Z


### PR DESCRIPTION
## Summary
- add an end-to-end smoke test in `cmd/yolo-agent` for `concurrency=2` stream mode with seeded tk tasks
- decode streamed NDJSON to verify parse stability and assert that multiple worker IDs are emitted in `runner_started` events
- apply decoded events to monitor model and assert worker section rendering remains stable under concurrent task execution

## Testing
- go test ./cmd/yolo-agent -run TestE2E_StreamSmoke_ConcurrencyEmitsMultiWorkerParseableEvents
- go test ./...