### PR TITLE
feat: define landing queue state machine

### DIFF
--- a/.tickets/yr-07wc.md
+++ b/.tickets/yr-07wc.md
@@ -1,6 +1,6 @@
 ---
 id: yr-07wc
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-02-09T23:07:07Z

--- a/.tickets/yr-20os.md
+++ b/.tickets/yr-20os.md
@@ -1,6 +1,6 @@
 ---
 id: yr-20os
-status: in_progress
+status: closed
 deps: [yr-70la]
 links: []
 created: 2026-02-09T23:07:08Z

--- a/internal/scheduler/landing_state_machine.go
+++ b/internal/scheduler/landing_state_machine.go
@@ -1,0 +1,114 @@
+package scheduler
+
+import "fmt"
+
+type LandingState string
+
+const (
+	LandingStateQueued   LandingState = "queued"
+	LandingStateLanding  LandingState = "landing"
+	LandingStateRetrying LandingState = "retrying"
+	LandingStateBlocked  LandingState = "blocked"
+	LandingStateLanded   LandingState = "landed"
+)
+
+func (s LandingState) IsTerminal() bool {
+	return s == LandingStateBlocked || s == LandingStateLanded
+}
+
+type LandingEvent string
+
+const (
+	LandingEventBegin           LandingEvent = "begin"
+	LandingEventSucceeded       LandingEvent = "succeeded"
+	LandingEventFailedRetryable LandingEvent = "failed_retryable"
+	LandingEventFailedPermanent LandingEvent = "failed_permanent"
+	LandingEventRequeued        LandingEvent = "requeued"
+)
+
+type LandingQueueStateMachine struct {
+	state       LandingState
+	attempts    int
+	maxAttempts int
+}
+
+func NewLandingQueueStateMachine(maxAttempts int) *LandingQueueStateMachine {
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	return &LandingQueueStateMachine{state: LandingStateQueued, maxAttempts: maxAttempts}
+}
+
+func (m *LandingQueueStateMachine) State() LandingState {
+	if m == nil {
+		return LandingStateQueued
+	}
+	return m.state
+}
+
+func (m *LandingQueueStateMachine) Attempts() int {
+	if m == nil {
+		return 0
+	}
+	return m.attempts
+}
+
+func (m *LandingQueueStateMachine) Apply(event LandingEvent) error {
+	if m == nil {
+		return fmt.Errorf("state machine is nil")
+	}
+	if m.state.IsTerminal() {
+		return fmt.Errorf("cannot apply %q in terminal state %q", event, m.state)
+	}
+
+	switch m.state {
+	case LandingStateQueued:
+		if event != LandingEventBegin {
+			return m.invalidTransition(event)
+		}
+		m.state = LandingStateLanding
+		return nil
+
+	case LandingStateLanding:
+		switch event {
+		case LandingEventSucceeded:
+			m.state = LandingStateLanded
+			return nil
+		case LandingEventFailedPermanent:
+			m.attempts++
+			m.state = LandingStateBlocked
+			return nil
+		case LandingEventFailedRetryable:
+			m.attempts++
+			if m.attempts >= m.maxAttempts {
+				m.state = LandingStateBlocked
+				return nil
+			}
+			m.state = LandingStateRetrying
+			return nil
+		default:
+			return m.invalidTransition(event)
+		}
+
+	case LandingStateRetrying:
+		switch event {
+		case LandingEventRequeued:
+			m.state = LandingStateQueued
+			return nil
+		case LandingEventBegin:
+			m.state = LandingStateLanding
+			return nil
+		case LandingEventFailedPermanent:
+			m.state = LandingStateBlocked
+			return nil
+		default:
+			return m.invalidTransition(event)
+		}
+	}
+
+	return m.invalidTransition(event)
+}
+
+func (m *LandingQueueStateMachine) invalidTransition(event LandingEvent) error {
+	return fmt.Errorf("invalid landing transition: state=%q event=%q", m.state, event)
+}

--- a/internal/scheduler/landing_state_machine_test.go
+++ b/internal/scheduler/landing_state_machine_test.go
@@ -1,0 +1,110 @@
+package scheduler
+
+import "testing"
+
+func TestLandingQueueStateMachineHappyPath(t *testing.T) {
+	sm := NewLandingQueueStateMachine(3)
+
+	if err := sm.Apply(LandingEventBegin); err != nil {
+		t.Fatalf("begin landing failed: %v", err)
+	}
+	if sm.State() != LandingStateLanding {
+		t.Fatalf("expected landing state, got %s", sm.State())
+	}
+
+	if err := sm.Apply(LandingEventSucceeded); err != nil {
+		t.Fatalf("landing success failed: %v", err)
+	}
+	if sm.State() != LandingStateLanded {
+		t.Fatalf("expected landed state, got %s", sm.State())
+	}
+}
+
+func TestLandingQueueStateMachineRetryPath(t *testing.T) {
+	sm := NewLandingQueueStateMachine(3)
+
+	if err := sm.Apply(LandingEventBegin); err != nil {
+		t.Fatalf("begin landing failed: %v", err)
+	}
+	if err := sm.Apply(LandingEventFailedRetryable); err != nil {
+		t.Fatalf("mark retryable failure failed: %v", err)
+	}
+	if sm.State() != LandingStateRetrying {
+		t.Fatalf("expected retrying state, got %s", sm.State())
+	}
+	if sm.Attempts() != 1 {
+		t.Fatalf("expected attempts=1, got %d", sm.Attempts())
+	}
+
+	if err := sm.Apply(LandingEventRequeued); err != nil {
+		t.Fatalf("requeue failed: %v", err)
+	}
+	if sm.State() != LandingStateQueued {
+		t.Fatalf("expected queued state, got %s", sm.State())
+	}
+
+	if err := sm.Apply(LandingEventBegin); err != nil {
+		t.Fatalf("begin landing second attempt failed: %v", err)
+	}
+	if err := sm.Apply(LandingEventSucceeded); err != nil {
+		t.Fatalf("landing success failed: %v", err)
+	}
+	if sm.State() != LandingStateLanded {
+		t.Fatalf("expected landed state, got %s", sm.State())
+	}
+}
+
+func TestLandingQueueStateMachineBlocksAfterMaxAttempts(t *testing.T) {
+	sm := NewLandingQueueStateMachine(2)
+
+	if err := sm.Apply(LandingEventBegin); err != nil {
+		t.Fatalf("begin landing failed: %v", err)
+	}
+	if err := sm.Apply(LandingEventFailedRetryable); err != nil {
+		t.Fatalf("mark retryable failure failed: %v", err)
+	}
+	if err := sm.Apply(LandingEventRequeued); err != nil {
+		t.Fatalf("requeue failed: %v", err)
+	}
+
+	if err := sm.Apply(LandingEventBegin); err != nil {
+		t.Fatalf("begin landing second attempt failed: %v", err)
+	}
+	if err := sm.Apply(LandingEventFailedRetryable); err != nil {
+		t.Fatalf("mark retryable failure failed: %v", err)
+	}
+
+	if sm.State() != LandingStateBlocked {
+		t.Fatalf("expected blocked state, got %s", sm.State())
+	}
+	if sm.Attempts() != 2 {
+		t.Fatalf("expected attempts=2, got %d", sm.Attempts())
+	}
+}
+
+func TestLandingQueueStateMachineRejectsInvalidTransitions(t *testing.T) {
+	sm := NewLandingQueueStateMachine(2)
+
+	if err := sm.Apply(LandingEventSucceeded); err == nil {
+		t.Fatalf("expected invalid transition error")
+	}
+	if sm.State() != LandingStateQueued {
+		t.Fatalf("expected state to remain queued, got %s", sm.State())
+	}
+}
+
+func TestLandingQueueStateMachineTerminalStatesRejectFurtherEvents(t *testing.T) {
+	tests := []LandingState{LandingStateBlocked, LandingStateLanded}
+	for _, terminal := range tests {
+		t.Run(string(terminal), func(t *testing.T) {
+			sm := NewLandingQueueStateMachine(2)
+			sm.state = terminal
+			if err := sm.Apply(LandingEventBegin); err == nil {
+				t.Fatalf("expected terminal transition to fail")
+			}
+			if sm.State() != terminal {
+				t.Fatalf("expected state to remain %s, got %s", terminal, sm.State())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated landing queue state machine in `internal/scheduler` covering `queued`, `landing`, `retrying`, `blocked`, and `landed`
- model explicit transition events (`begin`, `succeeded`, `failed_retryable`, `failed_permanent`, `requeued`) with deterministic validation errors for invalid transitions
- include retry-attempt tracking and max-attempt blocking behavior, with failing-first unit tests for happy path, retry path, exhaustion, invalid, and terminal-state transitions

## Testing
- go test ./internal/scheduler -run TestLandingQueueStateMachine
- go test ./...