### PR TITLE
feat: stream ACP permission details to runner updates

### DIFF
--- a/internal/opencode/acp_client.go
+++ b/internal/opencode/acp_client.go
@@ -26,23 +26,23 @@ const (
 type ACPHandler struct {
 	issueID string
 	logPath string
-	logger  func(string, string, string, string) error
+	logger  func(string, string, string, string, string) error
 }
 
-func NewACPHandler(issueID string, logPath string, logger func(string, string, string, string) error) *ACPHandler {
+func NewACPHandler(issueID string, logPath string, logger func(string, string, string, string, string) error) *ACPHandler {
 	return &ACPHandler{issueID: issueID, logPath: logPath, logger: logger}
 }
 
 func (h *ACPHandler) HandlePermission(ctx context.Context, requestID string, scope string) ACPDecision {
 	if h != nil && h.logger != nil {
-		_ = h.logger(h.logPath, h.issueID, "permission", "allow")
+		_ = h.logger(h.logPath, h.issueID, "permission", "allow", scope)
 	}
 	return ACPDecisionAllow
 }
 
 func (h *ACPHandler) HandleQuestion(ctx context.Context, requestID string, prompt string) string {
 	if h != nil && h.logger != nil {
-		_ = h.logger(h.logPath, h.issueID, "question", "decide yourself")
+		_ = h.logger(h.logPath, h.issueID, "question", "decide yourself", prompt)
 	}
 	return "decide yourself"
 }

--- a/internal/opencode/acp_client_test.go
+++ b/internal/opencode/acp_client_test.go
@@ -26,7 +26,7 @@ func TestACPHandlerAutoApprovesPermission(t *testing.T) {
 func TestACPClientCancelsQuestionPermission(t *testing.T) {
 	var gotKind string
 	var gotOutcome string
-	handler := NewACPHandler("issue-1", "log", func(_ string, _ string, kind string, outcome string) error {
+	handler := NewACPHandler("issue-1", "log", func(_ string, _ string, kind string, outcome string, _ string) error {
 		gotKind = kind
 		gotOutcome = outcome
 		return nil

--- a/internal/opencode/acp_console.go
+++ b/internal/opencode/acp_console.go
@@ -10,16 +10,38 @@ import (
 const acpConsoleSnippetLimit = 120
 
 func formatACPRequest(requestType string, decision string) string {
+	return formatACPRequestDetail(requestType, decision, "")
+}
+
+func formatACPRequestDetail(requestType string, decision string, detail string) string {
 	if requestType == "" && decision == "" {
 		return ""
 	}
+	detail = normalizeACPRequestDetail(detail)
+	detailText := ""
+	if detail != "" {
+		detailText = fmt.Sprintf(" detail=%q", detail)
+	}
 	if requestType == "" {
-		return fmt.Sprintf("request %s", decision)
+		return fmt.Sprintf("request %s%s", decision, detailText)
 	}
 	if decision == "" {
-		return fmt.Sprintf("request %s", requestType)
+		return fmt.Sprintf("request %s%s", requestType, detailText)
 	}
-	return fmt.Sprintf("request %s %s", requestType, decision)
+	return fmt.Sprintf("request %s %s%s", requestType, decision, detailText)
+}
+
+func normalizeACPRequestDetail(detail string) string {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(detail, "\n", " "), "\r", " "))
+	if trimmed == "" {
+		return ""
+	}
+	normalized := strings.Join(strings.Fields(trimmed), " ")
+	const maxLen = 160
+	if len(normalized) > maxLen {
+		return normalized[:maxLen] + "..."
+	}
+	return normalized
 }
 
 func formatSessionUpdate(update *acp.SessionUpdate) string {

--- a/internal/opencode/acp_console_test.go
+++ b/internal/opencode/acp_console_test.go
@@ -54,6 +54,14 @@ func TestFormatACPRequest(t *testing.T) {
 	}
 }
 
+func TestFormatACPRequestDetailIncludesNormalizedDetail(t *testing.T) {
+	got := formatACPRequestDetail("permission", "allow", "read   /tmp/file.txt\nwith context")
+	expected := "request permission allow detail=\"read /tmp/file.txt with context\""
+	if got != expected {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func TestFormatToolCallWithStatusBadges(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/opencode/client_test.go
+++ b/internal/opencode/client_test.go
@@ -427,3 +427,16 @@ func TestRunWithACPNoModelWhenEmpty(t *testing.T) {
 		t.Fatalf("expected empty config content, got %q", capturedEnv["OPENCODE_CONFIG_CONTENT"])
 	}
 }
+
+func TestForwardACPRequestLineForUpdates(t *testing.T) {
+	seen := []string{}
+	line := forwardACPRequestLine("permission", "allow", "read /tmp/file.txt", func(update string) {
+		seen = append(seen, update)
+	})
+	if line != "request permission allow detail=\"read /tmp/file.txt\"" {
+		t.Fatalf("unexpected request line: %q", line)
+	}
+	if len(seen) != 1 || seen[0] != line {
+		t.Fatalf("expected permission request forwarded once, got %#v", seen)
+	}
+}

--- a/internal/opencode/runner_adapter.go
+++ b/internal/opencode/runner_adapter.go
@@ -130,7 +130,7 @@ func normalizeACPUpdateLine(line string) (string, string) {
 		typeName = "runner_cmd_started"
 	case strings.HasPrefix(trimmed, "✅"), strings.HasPrefix(trimmed, "❌"):
 		typeName = "runner_cmd_finished"
-	case strings.HasPrefix(trimmed, "⚪"):
+	case strings.HasPrefix(trimmed, "⚪"), strings.HasPrefix(trimmed, "request permission"):
 		typeName = "runner_warning"
 	}
 	trimmed = strings.ReplaceAll(trimmed, "\r", "")

--- a/internal/opencode/runner_adapter_test.go
+++ b/internal/opencode/runner_adapter_test.go
@@ -243,3 +243,13 @@ func TestNormalizeACPUpdateLineRedactsAndTruncates(t *testing.T) {
 		t.Fatalf("expected bounded message length, got %d", len(normalizedLong))
 	}
 }
+
+func TestNormalizeACPUpdateLineClassifiesPermissionRequestsAsWarnings(t *testing.T) {
+	normalized, updateType := normalizeACPUpdateLine("request permission allow")
+	if normalized != "request permission allow" {
+		t.Fatalf("unexpected normalized line %q", normalized)
+	}
+	if updateType != "runner_warning" {
+		t.Fatalf("expected runner_warning for permission request, got %q", updateType)
+	}
+}


### PR DESCRIPTION
## Summary
- forward ACP permission/question request lines into the runner progress callback so they appear in streamed events
- include normalized request detail text (scope/title/prompt) in permission event lines and persist detail in ACP request log entries
- classify `request permission ...` lines as `runner_warning` in the runner adapter and add tests for formatting, forwarding, and classification

## Testing
- go test ./internal/opencode ./cmd/yolo-agent ./internal/agent
- go test ./...