### PR TITLE
feat: finalize backend runner result contract

### DIFF
--- a/.tickets/yr-70nw.md
+++ b/.tickets/yr-70nw.md
@@ -1,6 +1,6 @@
 ---
 id: yr-70nw
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-02-09T23:07:07Z

--- a/internal/contracts/backend_runner.go
+++ b/internal/contracts/backend_runner.go
@@ -1,0 +1,34 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type BackendErrorClassifier func(error) bool
+
+func NormalizeBackendRunnerResult(startedAt time.Time, finishedAt time.Time, request RunnerRequest, runErr error, isBlocked BackendErrorClassifier) RunnerResult {
+	result := RunnerResult{
+		LogPath:    "",
+		StartedAt:  startedAt,
+		FinishedAt: finishedAt,
+	}
+	if runErr == nil {
+		result.Status = RunnerResultCompleted
+		return result
+	}
+	if isBlocked != nil && isBlocked(runErr) {
+		result.Status = RunnerResultBlocked
+		result.Reason = runErr.Error()
+		return result
+	}
+	if request.Timeout > 0 && runErr == context.DeadlineExceeded {
+		result.Status = RunnerResultBlocked
+		result.Reason = fmt.Sprintf("runner timeout after %s", request.Timeout)
+		return result
+	}
+	result.Status = RunnerResultFailed
+	result.Reason = runErr.Error()
+	return result
+}

--- a/internal/contracts/backend_runner_test.go
+++ b/internal/contracts/backend_runner_test.go
@@ -1,0 +1,45 @@
+package contracts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeBackendRunnerResult(t *testing.T) {
+	started := time.Date(2026, 2, 10, 8, 0, 0, 0, time.UTC)
+	finished := started.Add(2 * time.Second)
+
+	blockedSentinel := errors.New("blocked")
+	tests := []struct {
+		name      string
+		request   RunnerRequest
+		runErr    error
+		isBlocked BackendErrorClassifier
+		want      RunnerResultStatus
+		contains  string
+	}{
+		{name: "implement success", request: RunnerRequest{Mode: RunnerModeImplement}, want: RunnerResultCompleted},
+		{name: "review success", request: RunnerRequest{Mode: RunnerModeReview}, want: RunnerResultCompleted},
+		{name: "blocked classified", request: RunnerRequest{Mode: RunnerModeImplement}, runErr: blockedSentinel, isBlocked: func(err error) bool { return errors.Is(err, blockedSentinel) }, want: RunnerResultBlocked, contains: "blocked"},
+		{name: "timeout maps to blocked", request: RunnerRequest{Mode: RunnerModeImplement, Timeout: time.Minute}, runErr: context.DeadlineExceeded, want: RunnerResultBlocked, contains: "runner timeout"},
+		{name: "generic maps to failed", request: RunnerRequest{Mode: RunnerModeImplement}, runErr: errors.New("boom"), want: RunnerResultFailed, contains: "boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeBackendRunnerResult(started, finished, tt.request, tt.runErr, tt.isBlocked)
+			if got.Status != tt.want {
+				t.Fatalf("status=%s want=%s", got.Status, tt.want)
+			}
+			if got.StartedAt != started || got.FinishedAt != finished {
+				t.Fatalf("unexpected timestamps: %#v", got)
+			}
+			if tt.contains != "" && !strings.Contains(got.Reason, tt.contains) {
+				t.Fatalf("expected reason to contain %q, got %q", tt.contains, got.Reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- introduce shared backend result normalization in `internal/contracts` to standardize completed/blocked/failed mapping across runner adapters
- cover contract behavior with table-driven tests for implement/review success, blocked classification, timeout-to-blocked mapping, and generic failures
- refactor opencode runner adapter to use the shared normalization helper while preserving review verdict handling and streamed progress mapping

## Testing
- go test ./internal/contracts -run TestNormalizeBackendRunnerResult
- go test ./internal/opencode
- go test ./...