### PR TITLE
chore: add E7 GUI epic task plan

### DIFF
--- a/.tickets/yr-09pb.md
+++ b/.tickets/yr-09pb.md
@@ -1,0 +1,25 @@
+---
+id: yr-09pb
+status: open
+deps: [yr-o4sq]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T17 Implement Elm-style Run->Workers->Tasks state model
+
+STRICT TDD: define immutable-ish derived GUI state model and reducer/update pipeline for stdin events without storing raw event lists.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Implement Model/Msg/Update/View using Bubble Tea; state hierarchy Run->Workers->Tasks; derived state only.
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: reducer must model per-scope error states (run-level, worker-level, task-level) with deterministic transitions and no raw-event dependency.

--- a/.tickets/yr-h9i3.md
+++ b/.tickets/yr-h9i3.md
@@ -1,0 +1,21 @@
+---
+id: yr-h9i3
+status: open
+deps: [yr-jy5d]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 1
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T23 Production polish and docs for GUI workflow
+
+STRICT TDD where applicable: finalize styles/components, update migration and operator docs, add runbook and examples for production usage.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD where applicable. Final polish/docs must explicitly document required UI libs: Bubble Tea, Bubbles, Lip Gloss and Elm-style architecture expectations.

--- a/.tickets/yr-iija.md
+++ b/.tickets/yr-iija.md
@@ -1,0 +1,25 @@
+---
+id: yr-iija
+status: open
+deps: [yr-09pb, yr-x1rh]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T19 Build status bar metrics and activity indicators
+
+STRICT TDD: implement status bar with runtime, spinner/activity, completed/in-progress/blocked/failed/total counts, queue depth, worker utilization, and event throughput.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Add failing view/state tests for status bar metrics (runtime, spinner, completed/in-progress/blocked/failed/total, queue depth, utilization, throughput).
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: status bar must expose aggregated error indicators by scope and severity (run/workers/tasks).

--- a/.tickets/yr-jy5d.md
+++ b/.tickets/yr-jy5d.md
@@ -1,0 +1,25 @@
+---
+id: yr-jy5d
+status: open
+deps: [yr-o4sq, yr-09pb, yr-x1rh, yr-iija, yr-qmru, yr-uby7]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T22 End-to-end stdin GUI contract tests
+
+STRICT TDD: add e2e and integration tests that feed NDJSON via stdin and verify state transitions, metrics, interaction behavior, and deterministic rendering semantics.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. E2E stdin contract tests must be written first and must validate deterministic rendering/state transitions with Bubble Tea model.
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: E2E tests must include malformed events, decode failures, transition conflicts, and renderer-safe fallback behavior.

--- a/.tickets/yr-o4sq.md
+++ b/.tickets/yr-o4sq.md
@@ -1,0 +1,25 @@
+---
+id: yr-o4sq
+status: open
+deps: []
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T16 Add run params startup stream event
+
+STRICT TDD: add explicit startup event emitted by yolo-agent with initial run parameters (root id, concurrency, model, timeout, stream flags, start time) for GUI initialization.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Start with failing tests for startup run-params event emission/consumption before implementation.
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: startup run-params event must include robust validation/error fallback behavior and test cases for malformed/missing startup payloads.

--- a/.tickets/yr-qmru.md
+++ b/.tickets/yr-qmru.md
@@ -1,0 +1,25 @@
+---
+id: yr-qmru
+status: open
+deps: [yr-09pb, yr-x1rh]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T20 Add hierarchical worker/task panels with expand-collapse
+
+STRICT TDD: implement scrollable Run->Workers->Tasks UI with collapsed/expanded rows; support both arrows+enter/space and vim keys j/k/h/l.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Add failing interaction tests first for expand/collapse + navigation (arrow keys and vim keys j/k/h/l + enter/space). Use Bubbles components where appropriate.
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: expandable panels must surface scoped errors in collapsed and expanded states without ambiguity.

--- a/.tickets/yr-sbkp.md
+++ b/.tickets/yr-sbkp.md
@@ -1,0 +1,29 @@
+---
+id: yr-sbkp
+status: open
+deps: []
+links: []
+created: 2026-02-10T08:16:58Z
+type: epic
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-2y0b
+---
+# E7-GUI Elm-style TUI architecture and production UX
+
+Implement production-grade stdin-driven TUI architecture using Elm-like state/update/view model. State is derived (no raw event storage), hierarchy is Run->Workers->Tasks, support expand/collapse navigation, rich status bar metrics, and scale baseline of 10 workers/500 tasks.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+Implementation protocol (MANDATORY): STRICT TDD for every subtask: (1) write failing test first, (2) implement minimal code to pass, (3) refactor with tests green. No feature code before a failing test exists.
+
+**2026-02-10T08:19:52Z**
+
+UI stack requirement (MANDATORY): Bubble Tea + Bubbles + Lip Gloss. Use Elm-style architecture (Model/Msg/Update/View), with state derived from stdin NDJSON events (no raw event log state).
+
+**2026-02-10T08:25:05Z**
+
+Critical requirement: design error-state handling from the start across all layers (stream ingest, decode/schema, reducer/state transition, worker/task/runner derived state, render/view, interaction/input, and backend/landing/tracker integration). Error states must be first-class, test-driven, and visible in UI at appropriate scope.

--- a/.tickets/yr-uby7.md
+++ b/.tickets/yr-uby7.md
@@ -1,0 +1,21 @@
+---
+id: yr-uby7
+status: open
+deps: [yr-qmru, yr-iija]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T21 Add memory and render performance controls
+
+STRICT TDD: optimize state and rendering for baseline 10 workers/500 tasks using bounded derived caches, efficient diffing, and viewport-aware rendering.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Add failing performance/memory behavior tests first; enforce baseline support for 10 workers / 500 tasks.

--- a/.tickets/yr-x1rh.md
+++ b/.tickets/yr-x1rh.md
@@ -1,0 +1,25 @@
+---
+id: yr-x1rh
+status: open
+deps: [yr-09pb]
+links: []
+created: 2026-02-10T08:17:26Z
+type: task
+priority: 0
+assignee: Gennady Evstratov
+parent: yr-sbkp
+---
+# E7-T18 Derive runner phases and task summaries
+
+STRICT TDD: map incoming events to derived runner/task phases, counters, timing, warnings/errors, and command summaries for expanded views.
+
+
+## Notes
+
+**2026-02-10T08:19:52Z**
+
+STRICT TDD required. Add failing reducer tests for phase derivation, command summaries, warnings/errors, counters.
+
+**2026-02-10T08:25:05Z**
+
+Error-state design mandatory: derive and normalize runner/warning/error phases with explicit severity and lifecycle states (active/resolved/terminal).


### PR DESCRIPTION
## Summary
- add new E7 GUI epic under  for Elm-style stdin-driven TUI architecture
- add sequenced implementation tasks (T16-T23) with strict TDD protocol notes and required Bubble Tea/Bubbles/Lip Gloss stack
- include explicit cross-layer error-state requirements in epic/task notes from the start
