### PR TITLE
feat: implement derived Run->Workers->Tasks monitor state

### DIFF
--- a/.tickets/yr-09pb.md
+++ b/.tickets/yr-09pb.md
@@ -1,6 +1,6 @@
 ---
 id: yr-09pb
-status: open
+status: in_progress
 deps: [yr-o4sq]
 links: []
 created: 2026-02-10T08:17:26Z


### PR DESCRIPTION
## Summary
- add derived monitor state snapshot with explicit Run->Workers->Tasks hierarchy for stdin event reduction
- update reducer path to populate worker/task derived state on incoming events while keeping raw-event-free state
- add strict-TDD coverage validating run params ingestion and worker/task phase derivation

## Testing
- go test ./internal/ui/monitor -run TestModelBuildsDerivedRunWorkerTaskState
- go test ./...
