### PR TITLE
feat: derive runner phase and task summary state

### DIFF
--- a/.tickets/yr-x1rh.md
+++ b/.tickets/yr-x1rh.md
@@ -1,6 +1,6 @@
 ---
 id: yr-x1rh
-status: open
+status: in_progress
 deps: [yr-09pb]
 links: []
 created: 2026-02-10T08:17:26Z


### PR DESCRIPTION
## Summary
- extend monitor reducer to derive runner command/output/warning/task terminal summaries into task state
- track warning lifecycle (active/resolved), command counters, command summary strings, and terminal status for expanded views
- add strict-TDD tests validating derived command summary counters and warning lifecycle transitions

## Testing
- go test ./internal/ui/monitor -run TestModelDerivesRunnerCommandAndOutputSummaries
- go test ./internal/ui/monitor -run TestModelDerivesWarningLifecycleAsActiveThenResolved
- go test ./...
