### PR TITLE
feat: add monitor status bar metrics and severity indicators

### DIFF
--- a/.tickets/yr-iija.md
+++ b/.tickets/yr-iija.md
@@ -1,6 +1,6 @@
 ---
 id: yr-iija
-status: open
+status: closed
 deps: [yr-09pb, yr-x1rh]
 links: []
 created: 2026-02-10T08:17:26Z


### PR DESCRIPTION
## Summary
- add a monitor status bar with runtime, activity, task counters, queue depth, worker utilization, and throughput metrics
- derive and render aggregated run/worker/task severity indicators so warning and failure states are visible at a glance
- preserve task and worker queue/title context across partial events and add TDD coverage for the new status bar contract