### PR TITLE
feat: add hierarchical monitor panels with key navigation

### DIFF
--- a/.tickets/yr-qmru.md
+++ b/.tickets/yr-qmru.md
@@ -1,6 +1,6 @@
 ---
 id: yr-qmru
-status: open
+status: closed
 deps: [yr-09pb, yr-x1rh]
 links: []
 created: 2026-02-10T08:17:26Z


### PR DESCRIPTION
## Summary
- add a hierarchical Panels view that renders Run -> Workers -> Tasks with scoped severity indicators in collapsed and expanded states
- implement panel navigation and expand/collapse controls via arrow-style keys and vim keys (///) plus enter/space toggles
- add TDD coverage for keyboard navigation and expand/collapse interactions in monitor model tests