### PR TITLE
feat: add monitor performance controls for history and panels

### DIFF
--- a/.tickets/yr-uby7.md
+++ b/.tickets/yr-uby7.md
@@ -1,6 +1,6 @@
 ---
 id: yr-uby7
-status: open
+status: closed
 deps: [yr-qmru, yr-iija]
 links: []
 created: 2026-02-10T08:17:26Z


### PR DESCRIPTION
## Summary
- add bounded performance controls for monitor history and panel row caches to enforce memory limits under large task counts
- add viewport-aware panel rendering and truncation markers to keep render cost stable while preserving navigation
- expose performance snapshot metrics and add strict TDD coverage for bounded history and 10-worker/500-task panel behavior