### PR TITLE
docs: add GUI runbook and production workflow guidance

### DIFF
--- a/.tickets/yr-h9i3.md
+++ b/.tickets/yr-h9i3.md
@@ -1,6 +1,6 @@
 ---
 id: yr-h9i3
-status: open
+status: closed
 deps: [yr-jy5d]
 links: []
 created: 2026-02-10T08:17:26Z

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,6 +20,8 @@
 - Old TUI behavior in `yolo-runner`
 - New read-only monitor: `yolo-agent --stream ... | yolo-tui --events-stdin`
 
+The stdin monitor now tolerates malformed NDJSON lines by emitting `decode_error` warnings and continuing to render subsequent valid events.
+
 ## Compatibility Behavior
 
 Invoking `yolo-runner` prints a compatibility notice and continues to run, so existing scripts are preserved while migration proceeds.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ The repo now supports split v2 CLIs:
 
 See `MIGRATION.md` for command mapping and compatibility details.
 
+## GUI Architecture Requirements
+
+The production stdin monitor (`yolo-tui`) follows an Elm-style `Model/Update/View` architecture and uses:
+
+- Bubble Tea for event-driven terminal application state updates
+- Bubbles for reusable UI components and interaction primitives
+- Lip Gloss for deterministic styling/layout output
+
+These UI dependencies are mandatory for GUI workflow evolution and should be treated as part of the runtime contract.
+
 ## Location
 
 - Canonical script: `tools/yolo-runner/beads_yolo_runner.py`
@@ -76,6 +86,16 @@ Common options:
 - `--max N` limit number of tasks processed
 - `--dry-run` print the task prompt without running OpenCode
 - `--headless` disable the TUI (useful for CI or non-TTY runs)
+
+### Stdin GUI Operator Flow
+
+Use streaming mode to drive `yolo-tui` from stdin in real time:
+
+```
+./bin/yolo-agent --repo . --root <root-id> --model openai/gpt-5.3-codex --stream | ./bin/yolo-tui --events-stdin
+```
+
+The monitor is decoder-safe: malformed NDJSON lines are surfaced as `decode_error` warnings in the UI and stderr while valid subsequent events continue rendering.
 
 ### `--runner-timeout` profiles (`yolo-agent`)
 

--- a/docs/GUI_RUNBOOK.md
+++ b/docs/GUI_RUNBOOK.md
@@ -1,0 +1,36 @@
+# GUI Production Runbook
+
+## Preflight
+
+- Build binaries: `make build`
+- Verify smoke coverage: `make smoke-event-stream`
+- Confirm required UI stack dependencies in module graph: Bubble Tea, Bubbles, Lip Gloss
+- Ensure stdin stream mode is enabled for agent execution (`--stream`)
+
+## Standard Operator Flow
+
+Run the production monitor pipeline over stdin:
+
+```
+./bin/yolo-agent --repo . --root <root-id> --model openai/gpt-5.3-codex --stream | ./bin/yolo-tui --events-stdin
+```
+
+Shortcut form: `yolo-agent --stream | yolo-tui --events-stdin`.
+
+Expected behavior:
+
+- Status bar updates continuously with runtime, activity, task counters, queue depth, utilization, and throughput
+- Hierarchical panels show `Run -> Workers -> Tasks` with scoped severity indicators
+- History and panel rendering remain bounded under high event volume
+
+## Failure Handling
+
+- Malformed NDJSON input lines are converted into `decode_error` warnings in rendered output
+- Decode warnings are also written to stderr as `event decode warning: ...`
+- Stream processing continues unless repeated decode failures exceed safety threshold
+
+## Triage Checklist
+
+- If stream appears stalled, verify upstream producer emits newline-delimited JSON events
+- If warning severity remains elevated, inspect recent `decode_error` history lines first
+- If panel rows are truncated, adjust viewport/perf controls in monitor model for local diagnostics

--- a/internal/docs/gui_workflow_test.go
+++ b/internal/docs/gui_workflow_test.go
@@ -1,0 +1,69 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadmeDocumentsRequiredGUILibrariesAndArchitecture(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	readmePath := filepath.Join(repoRoot, "README.md")
+	contents, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+
+	readme := string(contents)
+	for _, expected := range []string{"Bubble Tea", "Bubbles", "Lip Gloss", "Elm-style"} {
+		if !strings.Contains(readme, expected) {
+			t.Fatalf("README missing GUI requirement: %s", expected)
+		}
+	}
+}
+
+func TestMigrationIncludesStdinGUIOperatorFlow(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	migrationPath := filepath.Join(repoRoot, "MIGRATION.md")
+	contents, err := os.ReadFile(migrationPath)
+	if err != nil {
+		t.Fatalf("read migration doc: %v", err)
+	}
+
+	migration := string(contents)
+	if !strings.Contains(migration, "yolo-agent --stream") || !strings.Contains(migration, "yolo-tui --events-stdin") {
+		t.Fatalf("MIGRATION missing stdin GUI flow command")
+	}
+	if !strings.Contains(migration, "decode_error") {
+		t.Fatalf("MIGRATION missing decode fallback guidance")
+	}
+}
+
+func TestGUIRunbookExistsWithProductionChecklist(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	runbookPath := filepath.Join(repoRoot, "docs", "GUI_RUNBOOK.md")
+	contents, err := os.ReadFile(runbookPath)
+	if err != nil {
+		t.Fatalf("read GUI runbook: %v", err)
+	}
+
+	runbook := string(contents)
+	for _, expected := range []string{"Production Runbook", "Preflight", "Failure Handling", "yolo-agent --stream"} {
+		if !strings.Contains(runbook, expected) {
+			t.Fatalf("GUI runbook missing %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- document mandatory GUI architecture requirements (Bubble Tea, Bubbles, Lip Gloss, Elm-style model/update/view expectations)
- add a production GUI runbook covering preflight checks, operator flow, and decode_error handling guidance
- add documentation contract tests to keep README, MIGRATION, and runbook guidance synchronized