### PR TITLE
fix: point task clone origin at source upstream

### DIFF
--- a/internal/agent/clone_manager_test.go
+++ b/internal/agent/clone_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,38 @@ func TestGitCloneManagerClonesRepoPerTaskAndCleansUp(t *testing.T) {
 	}
 }
 
+func TestGitCloneManagerSetsCloneOriginToSourceUpstream(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	remoteRoot := t.TempDir()
+	remotePath := filepath.Join(remoteRoot, "remote.git")
+	runGit(t, remoteRoot, "init", "--bare", remotePath)
+
+	repoRoot := t.TempDir()
+	runGit(t, repoRoot, "init")
+	readmePath := filepath.Join(repoRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	runGit(t, repoRoot, "remote", "add", "origin", remotePath)
+
+	manager := NewGitCloneManager(t.TempDir())
+	clonePath, err := manager.CloneForTask(context.Background(), "t-remote", repoRoot)
+	if err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	defer func() { _ = manager.Cleanup("t-remote") }()
+
+	originURL := strings.TrimSpace(runGitOutput(t, clonePath, "remote", "get-url", "origin"))
+	if originURL != remotePath {
+		t.Fatalf("expected clone origin=%q, got %q", remotePath, originURL)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -53,4 +86,15 @@ func runGit(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v failed: %v (%s)", args, err, string(out))
 	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v (%s)", args, err, string(out))
+	}
+	return string(out)
 }


### PR DESCRIPTION
## Summary
- update clone creation so each task clone rewrites its `origin` remote to match the source repository's upstream `origin` URL
- prevent landing pushes from targeting the local checked-out repository path when runs start with `--repo .`
- add coverage to verify clone origin is set to the source upstream and preserve behavior when source has no configured origin

## Validation
- `go test ./internal/agent`
- `go test ./cmd/yolo-agent`