### PR TITLE
fix: expose explicit review verdict failures in events and TUI

### DIFF
--- a/cmd/yolo-agent/main.go
+++ b/cmd/yolo-agent/main.go
@@ -200,6 +200,7 @@ func runWithComponents(ctx context.Context, cfg runConfig, taskManager contracts
 		SchedulerStatePath: filepath.Join(cfg.repoRoot, ".yolo-runner", "scheduler-state.json"),
 		DryRun:             cfg.dryRun,
 		RepoRoot:           cfg.repoRoot,
+		Backend:            cfg.backend,
 		Model:              cfg.model,
 		RunnerTimeout:      cfg.runnerTimeout,
 		WatchdogTimeout:    cfg.watchdogTimeout,

--- a/internal/ui/monitor/model.go
+++ b/internal/ui/monitor/model.go
@@ -390,9 +390,16 @@ func applyDerivedTaskEvent(task *TaskState, event contracts.Event) {
 		task.WarningActive = false
 		task.TerminalStatus = strings.TrimSpace(event.Message)
 		task.LastSeverity = severityFromTerminalStatus(task.TerminalStatus)
+	case contracts.EventTypeReviewFinished:
+		if reason := strings.TrimSpace(event.Metadata["reason"]); reason != "" {
+			task.LastMessage = strings.TrimSpace(event.Message) + " | " + reason
+		}
 	case contracts.EventTypeTaskFinished:
 		task.TerminalStatus = strings.TrimSpace(event.Message)
 		task.LastSeverity = severityFromTerminalStatus(task.TerminalStatus)
+		if reason := strings.TrimSpace(event.Metadata["triage_reason"]); reason != "" {
+			task.LastMessage = task.TerminalStatus + " | " + reason
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- include backend-aware runner metadata (`backend=codex|opencode`) in `runner_started` events instead of hardcoding `opencode`
- preserve and emit explicit review verdict metadata (`review_verdict`, `reason`) so failed reviews surface actionable causes (`review verdict returned fail`) without ambiguous retry outcomes
- attach triage metadata (`triage_status`, `triage_reason`) to `task_finished` and surface it in monitor worker summaries so yolo-tui shows why a task failed directly in activity/status panes

## Validation
- `go test ./...`