### PR TITLE
fix(arcpr): correct Arcanum review-request listing contract (PR detection was broken)

### DIFF
--- a/cmd/yolo-agent/source_arcpr_test.go
+++ b/cmd/yolo-agent/source_arcpr_test.go
@@ -265,20 +265,14 @@ arc_review_watch:
 			t.Fatalf("path = %q, want /api/v1/review-requests", got)
 		}
 		query := r.URL.Query()
-		if got := query.Get("status"); got != "open" {
-			t.Fatalf("status = %q, want open", got)
-		}
-
-		reviewer := query.Get("reviewer")
-		author := query.Get("author")
-		switch {
-		case reviewer == "alice" && author == "":
+		switch q := query.Get("query"); {
+		case q == "subscriber(alice);open()":
 			listCalls = append(listCalls, "reviewer")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`[{"id":"777","from_id":"rev-777","status":"open","summary":"Ready for review","reviewers":["alice"],"to_branch":"trunk"}]`)); err != nil {
 				t.Fatalf("write reviewer response: %v", err)
 			}
-		case author == "alice" && reviewer == "":
+		case q == "author(alice);open()":
 			listCalls = append(listCalls, "author")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`[]`)); err != nil {

--- a/docs/arc-review-watch.md
+++ b/docs/arc-review-watch.md
@@ -16,8 +16,10 @@ The Arc PR source is cross-project and API-backed. It discovers PRs for the conf
 
 Discovery uses these API paths:
 
-- **Reviewer** PRs assigned to that login from `/api/v1/public/review-requests?status=open&reviewer=<login>`.
-- **Authored** PRs created by that login from `/api/v1/public/review-requests?status=open&author=<login>`.
+- **Reviewer** PRs the login is subscribed to from `/api/v1/review-requests?query=subscriber(<login>);open()&fields=review_requests(...)`.
+- **Authored** PRs created by that login from `/api/v1/review-requests?query=author(<login>);open()&fields=review_requests(...)`.
+
+Arcanum's review-request collection is not a plain filtered GET: it returns an empty `{"data":{}}` unless the row selection is expressed in its query DSL (`query=...;open()`) **and** the columns are projected via `fields=review_requests(...)`; the items then appear under `data.review_requests`. `reviewer(<login>)` is not a valid predicate, so reviewer PRs use `subscriber(<login>)`. The list API exposes no commit SHA in projection, so `active_diff_set(id)` — which changes on every push — is used as the revision change-token for idempotency and re-review-on-update.
 
 The source records the PR id, head revision, unanswered comments, and `allow_ship` flag in a queue item for the profile's preset.
 

--- a/internal/arcanum/pr_list.go
+++ b/internal/arcanum/pr_list.go
@@ -203,10 +203,38 @@ func (c *PRListArcanumClient) api() (*APIClient, error) {
 	return c.apiClient, nil
 }
 
+// arcReviewRequestListLimit bounds a single review-request listing page. Arcanum
+// caps projection to the requested fields, so a generous page is cheap; 1000
+// matches other internal clients (bazel-steward) and covers any realistic user.
+const arcReviewRequestListLimit = "1000"
+
+// reviewRequestsPath builds the Arcanum review-request collection query.
+//
+// Arcanum's /v1/review-requests is not a plain GET-with-filters: it returns an
+// empty {"data":{}} unless BOTH (a) the row selection is expressed in Arcanum's
+// query DSL via the `query` param and (b) the columns are projected via
+// `fields=review_requests(...)`. The DSL predicate selecting authored PRs is
+// author(<login>); there is no reviewer(<login>) predicate, so PRs the user is
+// asked to review are selected with subscriber(<login>). open() keeps only open
+// review requests.
+//
+// active_diff_set(id) is the only per-push identifier the list API exposes (no
+// commit SHA is available in list projection); it changes on every push, so it
+// serves as the revision change-token used downstream for idempotency and
+// re-review-on-update. vcs(from_branch,to_branch) feeds the branch fields.
 func reviewRequestsPath(filter string, user string) string {
+	user = strings.TrimSpace(user)
+	predicate := "author"
+	if filter == "reviewer" {
+		predicate = "subscriber"
+	}
+
 	query := url.Values{}
-	query.Set("status", "open")
-	query.Set(filter, strings.TrimSpace(user))
+	query.Set("query", predicate+"("+user+");open()")
+	query.Set("fields", "review_requests(id,author,summary,status,active_diff_set(id),vcs(from_branch,to_branch))")
+	query.Set("order", "-updated_at")
+	query.Set("limit", arcReviewRequestListLimit)
+	query.Set("offset", "0")
 	return "/v1/review-requests?" + query.Encode()
 }
 

--- a/internal/arcanum/pr_list_parser.go
+++ b/internal/arcanum/pr_list_parser.go
@@ -41,7 +41,7 @@ func prListItems(data []byte) ([]json.RawMessage, error) {
 		return nil, fmt.Errorf("parse arc pr list JSON: %w", err)
 	}
 
-	for _, key := range []string{"pull_requests", "pullRequests", "prs", "items", "result", "data"} {
+	for _, key := range []string{"review_requests", "reviewRequests", "pull_requests", "pullRequests", "prs", "items", "result", "data"} {
 		raw := object[key]
 		if len(raw) == 0 {
 			continue
@@ -94,6 +94,20 @@ func parsePRSummary(raw json.RawMessage) (PRSummary, error) {
 	summary := firstScalar(item, "summary", "title", "name")
 	fromBranch := firstScalar(item, "from_branch", "fromBranch", "source_branch", "sourceBranch")
 	toBranch := firstScalar(item, "to_branch", "toBranch", "target_branch", "targetBranch", "base_branch", "baseBranch")
+	fromID := firstScalar(item, "from_id", "fromId", "head_id", "headId", "head_commit", "headCommit", "revision", "current_revision", "currentRevision")
+
+	// Arcanum's HTTP list API nests branches under "vcs" and exposes the per-push
+	// identifier as active_diff_set.id; fall back to those when the flat fields
+	// (emitted by the arc CLI) are absent.
+	if fromBranch == "" {
+		fromBranch = nestedScalar(item, "vcs", "from_branch", "fromBranch", "source_branch", "sourceBranch")
+	}
+	if toBranch == "" {
+		toBranch = nestedScalar(item, "vcs", "to_branch", "toBranch", "target_branch", "targetBranch", "base_branch", "baseBranch")
+	}
+	if fromID == "" {
+		fromID = nestedScalar(item, "active_diff_set", "id")
+	}
 
 	return PRSummary{
 		ID:         firstScalar(item, "id", "number", "pr_id", "pull_request_id"),
@@ -103,11 +117,26 @@ func parsePRSummary(raw json.RawMessage) (PRSummary, error) {
 		Reviewers:  firstPeopleList(item, "reviewers", "reviewer_logins"),
 		Branch:     firstNonEmpty(toBranch, firstScalar(item, "branch"), fromBranch),
 		FromBranch: fromBranch,
-		FromID:     firstScalar(item, "from_id", "fromId", "head_id", "headId", "head_commit", "headCommit", "revision", "current_revision", "currentRevision"),
+		FromID:     fromID,
 		ToBranch:   toBranch,
 		Status:     firstScalar(item, "status", "state"),
 		Issues:     firstIssueList(item, "issues", "linked_issues", "linkedIssues"),
 	}, nil
+}
+
+// nestedScalar reads a scalar from a nested object (e.g. vcs.from_branch or
+// active_diff_set.id) emitted by Arcanum's HTTP list API. Returns "" when the
+// object or none of the fields are present.
+func nestedScalar(item map[string]json.RawMessage, objectKey string, fieldKeys ...string) string {
+	raw := item[objectKey]
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		return ""
+	}
+	return firstScalar(nested, fieldKeys...)
 }
 
 func firstScalar(item map[string]json.RawMessage, keys ...string) string {

--- a/internal/arcanum/pr_list_parser_test.go
+++ b/internal/arcanum/pr_list_parser_test.go
@@ -149,3 +149,52 @@ func TestParsePRListJSONAcceptsNestedDataItemsWrapper(t *testing.T) {
 		t.Fatalf("ParsePRListJSON(nested data items wrapper) = %#v, want %#v", got, want)
 	}
 }
+
+// TestParsePRListJSONArcanumHTTPShape locks in the contract returned by the
+// Arcanum /v1/review-requests collection (query DSL + fields projection): the
+// items live under data.review_requests, branches nest under vcs, and the only
+// per-push identifier is active_diff_set.id (used as the revision change-token).
+// Regression for the discovery bug where the collection returned {data:{}}.
+func TestParsePRListJSONArcanumHTTPShape(t *testing.T) {
+	fixture := []byte(`{
+  "data": {
+    "review_requests": [
+      {
+        "id": 14107203,
+        "author": {"name": "genaevstratov"},
+        "summary": "Add Dino Messenger Deploy env helper",
+        "vcs": {"from_branch": "users/genaevstratov/dino-messenger-deploy-env", "to_branch": "trunk"},
+        "status": "published",
+        "reviewers": []
+      }
+    ]
+  }
+}`)
+
+	got, err := ParsePRListJSON(fixture)
+	if err != nil {
+		t.Fatalf("ParsePRListJSON(arcanum http shape) error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ParsePRListJSON(arcanum http shape) len = %d, want 1", len(got))
+	}
+	pr := got[0]
+	if pr.ID != "14107203" {
+		t.Errorf("ID = %q, want 14107203", pr.ID)
+	}
+	if pr.Author != "genaevstratov" {
+		t.Errorf("Author = %q, want genaevstratov", pr.Author)
+	}
+	if pr.Summary != "Add Dino Messenger Deploy env helper" {
+		t.Errorf("Summary = %q", pr.Summary)
+	}
+	if pr.Status != "published" {
+		t.Errorf("Status = %q, want published", pr.Status)
+	}
+	if pr.FromBranch != "users/genaevstratov/dino-messenger-deploy-env" {
+		t.Errorf("FromBranch = %q", pr.FromBranch)
+	}
+	if pr.ToBranch != "trunk" {
+		t.Errorf("ToBranch = %q, want trunk", pr.ToBranch)
+	}
+}

--- a/internal/arcanum/pr_list_test.go
+++ b/internal/arcanum/pr_list_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -18,11 +19,17 @@ func TestPRListArcanumClientReviewerQueryUsesOAuthAndFilters(t *testing.T) {
 			t.Fatalf("path = %q, want /api/v1/review-requests", got)
 		}
 		query := r.URL.Query()
-		if got := query.Get("status"); got != "open" {
-			t.Fatalf("status = %q, want open", got)
+		if got := query.Get("query"); got != "subscriber(alice);open()" {
+			t.Fatalf("query = %q, want subscriber(alice);open()", got)
 		}
-		if got := query.Get("reviewer"); got != "alice" {
-			t.Fatalf("reviewer = %q, want alice", got)
+		if fields := query.Get("fields"); !strings.Contains(fields, "review_requests(") {
+			t.Fatalf("fields = %q, want a review_requests(...) projection", fields)
+		}
+		if got := query.Get("status"); got != "" {
+			t.Fatalf("status = %q, want empty (open-ness is the open() predicate)", got)
+		}
+		if got := query.Get("reviewer"); got != "" {
+			t.Fatalf("reviewer = %q, want empty (filter is in the query DSL)", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "OAuth api-token" {
 			t.Fatalf("Authorization = %q, want OAuth api-token", got)
@@ -66,11 +73,14 @@ func TestPRListArcanumClientAuthorQueryUsesOAuthAndFilters(t *testing.T) {
 			t.Fatalf("path = %q, want /api/v1/review-requests", got)
 		}
 		query := r.URL.Query()
-		if got := query.Get("status"); got != "open" {
-			t.Fatalf("status = %q, want open", got)
+		if got := query.Get("query"); got != "author(alice);open()" {
+			t.Fatalf("query = %q, want author(alice);open()", got)
 		}
-		if got := query.Get("author"); got != "alice" {
-			t.Fatalf("author = %q, want alice", got)
+		if fields := query.Get("fields"); !strings.Contains(fields, "review_requests(") {
+			t.Fatalf("fields = %q, want a review_requests(...) projection", fields)
+		}
+		if got := query.Get("author"); got != "" {
+			t.Fatalf("author = %q, want empty (filter is in the query DSL)", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "OAuth api-token" {
 			t.Fatalf("Authorization = %q, want OAuth api-token", got)
@@ -123,8 +133,8 @@ func TestListReviewPRsWithClientDedupeReviewerThenAuthor(t *testing.T) {
 			t.Fatalf("Authorization = %q, want OAuth test-token", got)
 		}
 
-		switch {
-		case query.Get("reviewer") == "alice":
+		switch q := query.Get("query"); {
+		case q == "subscriber(alice);open()":
 			requests = append(requests, "reviewer")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`{
@@ -136,7 +146,7 @@ func TestListReviewPRsWithClientDedupeReviewerThenAuthor(t *testing.T) {
 				t.Fatalf("write reviewer response: %v", err)
 			}
 
-		case query.Get("author") == "alice":
+		case q == "author(alice);open()":
 			requests = append(requests, "author")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`{"data":[

--- a/internal/docs/arc_review_watch_runbook_test.go
+++ b/internal/docs/arc_review_watch_runbook_test.go
@@ -69,8 +69,8 @@ func TestArcReviewDocsDescribeCrossProjectPRReviewModel(t *testing.T) {
 	runbookRequired := []string{
 		"API-backed",
 		"Arcanum public API",
-		"/api/v1/public/review-requests?status=open&reviewer=<login>",
-		"/api/v1/public/review-requests?status=open&author=<login>",
+		"/api/v1/review-requests?query=subscriber(<login>);open()&fields=review_requests(...)",
+		"/api/v1/review-requests?query=author(<login>);open()&fields=review_requests(...)",
 		"No mounted Arc workspace is needed for discovery",
 		"Each PR review work item receives an isolated checkout",
 		"auto-detects the project root from changed files",

--- a/internal/sources/arcpr/discovery_test.go
+++ b/internal/sources/arcpr/discovery_test.go
@@ -199,14 +199,8 @@ func TestSourcePollUsesDefaultIncomingDiscoveryAndRuntimeStateWithoutWorkspacePi
 			t.Fatalf("path = %q, want /api/v1/review-requests", got)
 		}
 		query := r.URL.Query()
-		if got := query.Get("status"); got != "open" {
-			t.Fatalf("status = %q, want open", got)
-		}
-
-		reviewer := query.Get("reviewer")
-		author := query.Get("author")
-		switch {
-		case reviewer == "alice" && author == "":
+		switch q := query.Get("query"); {
+		case q == "subscriber(alice);open()":
 			listCalls = append(listCalls, "reviewer")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`[
@@ -216,7 +210,7 @@ func TestSourcePollUsesDefaultIncomingDiscoveryAndRuntimeStateWithoutWorkspacePi
 ]`)); err != nil {
 				t.Fatalf("write reviewer response: %v", err)
 			}
-		case author == "alice" && reviewer == "":
+		case q == "author(alice);open()":
 			listCalls = append(listCalls, "author")
 			w.Header().Set("Content-Type", "application/json")
 			if _, err := w.Write([]byte(`{"data":[{"id":"103","from_id":"rev-3","status":"open","summary":"authored head","author":"alice"}]}`)); err != nil {


### PR DESCRIPTION
## Problem
`yolo-agent source arcpr` discovered **zero** PRs. The configured reviewer has >20 open authored/reviewed PRs, but none were ever enqueued.

## Root cause
Arcanum's review-request collection (`GET /v1/review-requests`) is **not** a plain filtered GET. `?author=<login>&status=open` returns an empty `{"data":{}}` for *everyone*. Two things are required (confirmed via 4 internal clients surfaced by intrasearch `SearchCode`):

1. **`query=` DSL param** — `query=author(<login>);open()` for authored PRs; `query=subscriber(<login>);open()` for reviewed PRs (no `reviewer()` predicate — it 400s). `open()` is the open-state predicate, not `status=open`.
2. **`fields=review_requests(...)` projection is mandatory** — without it `data` is empty. Items live in `data.review_requests[]`.

The list/single API exposes no commit SHA in projection — only `active_diff_set(id)` (changes per push) and `vcs(from_branch,to_branch)`. `active_diff_set.id` is used as the revision change-token for idempotency + re-review-on-push.

## Changes (8 files)
- `internal/arcanum/pr_list.go` — `reviewRequestsPath` emits the DSL query + projection.
- `internal/arcanum/pr_list_parser.go` — recognizes `data.review_requests`; descends into nested `vcs` / `active_diff_set` (flat arc-CLI shape still works).
- Tests + `docs/arc-review-watch.md` updated off the old `?status=open&author=` contract; new regression test for the exact Arcanum shape.

## Verification
- `go test ./...` → 0 failures; `go build ./...` clean.
- **Live:** `yolo-agent source arcpr --once` now enqueues **22 PR review items** (authored + subscribed) where it previously found none.

## Out of scope (separate)
- Review *execution* still needs an arc mount (`FetchPRRuntimeState` shells to `arc pr status`/`changes`); this PR only fixes mount-free **detection**.
- Comment-resolve endpoint (U1) still unconfirmed against live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)