### PR TITLE
fix(arcpr): stop working on merged and discarded PRs

### DIFF
--- a/cmd/yolo-agent/prreview_e2e_test.go
+++ b/cmd/yolo-agent/prreview_e2e_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestPRReviewEndToEndOffline(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	ctx := context.Background()
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/yolo-agent/runner_implement.go
+++ b/cmd/yolo-agent/runner_implement.go
@@ -27,6 +27,10 @@ var runnerImplementPreparePRCheckout = func(prID string) (*arcanum.PRCheckout, e
 // landing-applicability check.
 var runnerImplementFetchPRComments = arcanum.FetchPRComments
 
+// runnerImplementFetchPRState is a seam over arcanum.FetchReviewRequestState
+// for the landing-applicability check.
+var runnerImplementFetchPRState = arcanum.FetchReviewRequestState
+
 // runnerImplementImplementSkippedStatus marks an implement result whose comment
 // no longer needed a fix at landing time. The arcpr source treats it as
 // terminal without posting a reply or resolving the thread.
@@ -47,6 +51,18 @@ func runnerImplementCommentObsoleteReason(ctx context.Context, payload workitem.
 	commentIDs := workitem.ImplementCommentIDs(meta)
 	if prID == "" || len(commentIDs) == 0 {
 		return "", nil
+	}
+	// A merged or discarded PR can take no landings at all — check it first so
+	// a closed PR costs one API call regardless of how many comments the item
+	// covers. Discovery cancels pending items for closed PRs, but an item that
+	// was already claimed (e.g. reaped from a dead runner's lease) still
+	// reaches this gate.
+	prState, err := runnerImplementFetchPRState(ctx, prID)
+	if err != nil {
+		return "", fmt.Errorf("check arc PR %q state before landing: %w", prID, err)
+	}
+	if arcanum.ReviewRequestStateClosed(prState) {
+		return fmt.Sprintf("PR %s is %s — nothing can land on a closed review request", prID, strings.TrimSpace(prState)), nil
 	}
 	comments, err := runnerImplementFetchPRComments(ctx, prID)
 	if err != nil {

--- a/cmd/yolo-agent/runner_implement_test.go
+++ b/cmd/yolo-agent/runner_implement_test.go
@@ -415,6 +415,7 @@ func TestRunnerImplementSkipsObsoleteAuthorComment(t *testing.T) {
 				runnerImplementFetchPRComments = prevFetch
 				runnerImplementPreparePRCheckout = prevPrepare
 			})
+			stubRunnerImplementPRState(t, "open")
 			fetchedPR := ""
 			runnerImplementFetchPRComments = func(_ context.Context, prID string) ([]arcreview.PRComment, error) {
 				fetchedPR = prID
@@ -480,6 +481,7 @@ func TestRunnerImplementProceedsWhenAuthorCommentStillApplicable(t *testing.T) {
 		runnerImplementFetchPRComments = prevFetch
 		runnerImplementPreparePRCheckout = prevPrepare
 	})
+	stubRunnerImplementPRState(t, "open")
 	runnerImplementFetchPRComments = func(context.Context, string) ([]arcreview.PRComment, error) {
 		return []arcreview.PRComment{
 			{ID: "c-1", Body: "please fix"},
@@ -550,6 +552,7 @@ func TestRunnerImplementBriefsAgentOnRebaseConflict(t *testing.T) {
 		}, nil
 	}
 	runnerImplementPRVCS = func(string) contracts.VCS { return &runnerImplementFakeVCS{} }
+	stubRunnerImplementPRState(t, "open")
 	runnerImplementFetchPRComments = func(context.Context, string) ([]arcreview.PRComment, error) {
 		return []arcreview.PRComment{{ID: "c-1", Body: "please fix", IssueStatus: "open"}}, nil
 	}
@@ -736,5 +739,85 @@ func TestRunnerImplementAuthorModeLandsOnExistingPR(t *testing.T) {
 	}
 	if fakeVCS.pushPRBranchPR != "PR-999" {
 		t.Fatalf("PushPRBranch pr = %q, want PR-999", fakeVCS.pushPRBranchPR)
+	}
+}
+
+// stubRunnerImplementPRState pins the PR-state seam to a fixed state for the
+// duration of a test so the gate never reaches the real Arcanum API.
+func stubRunnerImplementPRState(t *testing.T, state string) {
+	t.Helper()
+	prev := runnerImplementFetchPRState
+	t.Cleanup(func() { runnerImplementFetchPRState = prev })
+	runnerImplementFetchPRState = func(context.Context, string) (string, error) {
+		return state, nil
+	}
+}
+
+// A closed (merged/discarded) PR can take no landings: the applicability gate
+// must skip the item before fetching comments or preparing a checkout.
+func TestRunnerImplementSkipsWhenPRClosed(t *testing.T) {
+	prevState := runnerImplementFetchPRState
+	prevFetch := runnerImplementFetchPRComments
+	prevPrepare := runnerImplementPreparePRCheckout
+	t.Cleanup(func() {
+		runnerImplementFetchPRState = prevState
+		runnerImplementFetchPRComments = prevFetch
+		runnerImplementPreparePRCheckout = prevPrepare
+	})
+	statePR := ""
+	runnerImplementFetchPRState = func(_ context.Context, prID string) (string, error) {
+		statePR = prID
+		return "merged", nil
+	}
+	runnerImplementFetchPRComments = func(context.Context, string) ([]arcreview.PRComment, error) {
+		t.Fatal("comments must not be fetched for a closed PR")
+		return nil, nil
+	}
+	runnerImplementPreparePRCheckout = func(string) (*arcanum.PRCheckout, error) {
+		t.Fatal("prepare checkout must not run for a closed PR")
+		return nil, nil
+	}
+
+	handler := newRunnerImplementKindHandler(func(context.Context, workitem.Item, envpreset.Workspace) (runnerImplementExecutor, error) {
+		t.Fatal("executor must not be resolved for a closed PR")
+		return runnerImplementExecutor{}, nil
+	})
+	item := workitem.Item{
+		ID:   "item-closed-pr",
+		Kind: workitem.KindImplement,
+		Payload: marshalRunnerImplementPayload(t, workitem.ImplementPayload{
+			TaskID: "PR-42-c-1",
+			Title:  "Fix comment c-1",
+			PromptContext: workitem.ImplementPromptContext{
+				Prompt: "Apply the fix.",
+				Metadata: map[string]string{
+					"origin":         "arcpr-author",
+					"arc_pr_id":      "42",
+					"arc_comment_id": "c-1",
+					"arc_pr_author":  "alice",
+				},
+			},
+		}),
+	}
+
+	result, err := handler(context.Background(), item, envpreset.Workspace{})
+	if err != nil {
+		t.Fatalf("handler() error = %v", err)
+	}
+	if statePR != "42" {
+		t.Fatalf("fetched state for PR %q, want 42", statePR)
+	}
+	if result.Status != workqueue.ResultStatusCompleted {
+		t.Fatalf("result status = %q, want completed", result.Status)
+	}
+	implementResult, err := workitem.DecodeImplementResult(result.Payload)
+	if err != nil {
+		t.Fatalf("DecodeImplementResult() error = %v", err)
+	}
+	if implementResult.Status != runnerImplementSkippedStatus {
+		t.Fatalf("implement result status = %q, want %q", implementResult.Status, runnerImplementSkippedStatus)
+	}
+	if !strings.Contains(implementResult.Reason, "merged") {
+		t.Fatalf("implement result reason = %q, want it to mention the merged state", implementResult.Reason)
 	}
 }

--- a/cmd/yolo-agent/runner_prreview.go
+++ b/cmd/yolo-agent/runner_prreview.go
@@ -42,6 +42,10 @@ type runnerPRReviewRuntimeResolver func(context.Context, workitem.Item, envprese
 
 var prepareRunnerPRReviewCheckout = arcanum.PreparePRCheckoutWithConfig
 
+// runnerPRReviewFetchPRState is a seam over arcanum.FetchReviewRequestState
+// for the closed-PR preflight.
+var runnerPRReviewFetchPRState = arcanum.FetchReviewRequestState
+
 func newRunnerPRReviewKindHandler(resolve runnerPRReviewRuntimeResolver) runnerKindHandler {
 	if resolve == nil {
 		resolve = defaultRunnerPRReviewRuntimeResolver
@@ -62,6 +66,22 @@ func runRunnerPRReview(ctx context.Context, item workitem.Item, workspace envpre
 	payload, err := workitem.DecodePRReviewPayload(item.Payload)
 	if err != nil {
 		return workqueue.Result{}, fmt.Errorf("decode PR review payload for item %q: %w", item.ID, err)
+	}
+
+	// A merged or discarded PR needs no review in either mode. Discovery
+	// cancels pending items for closed PRs, but an item claimed before the PR
+	// closed (or reaped from a dead runner's lease) still reaches this
+	// handler; exit before any checkout or model work.
+	prState, err := runnerPRReviewFetchPRState(ctx, strings.TrimSpace(payload.PRID))
+	if err != nil {
+		return workqueue.Result{}, fmt.Errorf("check arc PR %q state for review item %q: %w", strings.TrimSpace(payload.PRID), item.ID, err)
+	}
+	if arcanum.ReviewRequestStateClosed(prState) {
+		emptyResult, err := json.Marshal(workitem.PRReviewResult{})
+		if err != nil {
+			return workqueue.Result{}, fmt.Errorf("marshal closed-PR review result for item %q: %w", item.ID, err)
+		}
+		return workqueue.Result{Payload: emptyResult}, nil
 	}
 
 	// Resolve the author runtime before preparing a checkout so an obsolete

--- a/cmd/yolo-agent/runner_prreview_test.go
+++ b/cmd/yolo-agent/runner_prreview_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestRunnerPRReviewHandlerWritesPRReviewResultRow(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	arcCallsPath := installRunnerPRReviewFakeArc(t)
@@ -184,6 +185,7 @@ func TestRunnerPRReviewHandlerWritesPRReviewResultRow(t *testing.T) {
 }
 
 func TestRunnerPRReviewSkipsStaleAuthorVersionBeforeRebase(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	payload, err := json.Marshal(workitem.PRReviewPayload{
 		PRID:     "42",
 		Revision: "stale-diff",
@@ -224,6 +226,7 @@ func TestRunnerPRReviewSkipsStaleAuthorVersionBeforeRebase(t *testing.T) {
 }
 
 func TestRunnerPRReviewHandlerPassesProjectContextIntoPrompt(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	installRunnerPRReviewFakeArc(t)
@@ -367,6 +370,7 @@ func TestRunnerPRReviewHandlerPassesProjectContextIntoPrompt(t *testing.T) {
 }
 
 func TestRunnerPRReviewSkipsPresetArcSharedMaterialization(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	arcCallsPath := installRunnerPRReviewFakeArc(t)
@@ -581,6 +585,7 @@ func assertRunnerPRReviewArcCalls(t *testing.T, path string, want []runnerPRRevi
 }
 
 func TestRunnerPRReviewHandlerAuthorModeBuildsAuthorPromptAndCapturesDecisions(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	mountPath := t.TempDir()
@@ -748,6 +753,7 @@ func TestRunnerPRReviewHandlerAuthorModeBuildsAuthorPromptAndCapturesDecisions(t
 }
 
 func TestRunnerPRReviewHandlerReviewerAnswerModeIsUnchanged(t *testing.T) {
+	stubRunnerPRReviewPRState(t, "open")
 	// The default reviewer mode on the answer path must keep building the
 	// reviewer prompt and capturing replies (not author comment decisions).
 	home := t.TempDir()
@@ -870,5 +876,66 @@ func TestRunnerPRReviewHandlerReviewerAnswerModeIsUnchanged(t *testing.T) {
 	}
 	if !reflect.DeepEqual(result, want) {
 		t.Fatalf("PR review result mismatch:\n got: %#v\nwant: %#v", result, want)
+	}
+}
+
+// stubRunnerPRReviewPRState pins the PR-state seam to a fixed state for the
+// duration of a test so the handler never reaches the real Arcanum API.
+func stubRunnerPRReviewPRState(t *testing.T, state string) {
+	t.Helper()
+	prev := runnerPRReviewFetchPRState
+	t.Cleanup(func() { runnerPRReviewFetchPRState = prev })
+	runnerPRReviewFetchPRState = func(context.Context, string) (string, error) {
+		return state, nil
+	}
+}
+
+// A merged/discarded PR needs no review in either mode: the handler must exit
+// with an empty result before resolving a runtime or preparing a checkout.
+func TestRunnerPRReviewSkipsClosedPR(t *testing.T) {
+	prevState := runnerPRReviewFetchPRState
+	prevPrepare := prepareRunnerPRReviewCheckout
+	t.Cleanup(func() {
+		runnerPRReviewFetchPRState = prevState
+		prepareRunnerPRReviewCheckout = prevPrepare
+	})
+	statePR := ""
+	runnerPRReviewFetchPRState = func(_ context.Context, prID string) (string, error) {
+		statePR = prID
+		return "discarded", nil
+	}
+	prepareRunnerPRReviewCheckout = func(context.Context, string, arcanum.PRCheckoutConfig) (*arcanum.PRCheckout, error) {
+		t.Fatal("checkout must not be prepared for a closed PR")
+		return nil, nil
+	}
+
+	payload, err := json.Marshal(workitem.PRReviewPayload{
+		PRID:     "42",
+		Revision: "final-diff",
+		Mode:     workitem.PRReviewModeAuthor,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	result, err := runRunnerPRReview(context.Background(), workitem.Item{
+		ID:      "closed-pr-review",
+		Kind:    workitem.KindPRReview,
+		Payload: payload,
+	}, envpreset.Workspace{}, func(context.Context, workitem.Item, envpreset.Workspace, workitem.PRReviewPayload) (runnerPRReviewRuntime, error) {
+		t.Fatal("runtime must not be resolved for a closed PR")
+		return runnerPRReviewRuntime{}, nil
+	})
+	if err != nil {
+		t.Fatalf("runRunnerPRReview() error = %v", err)
+	}
+	if statePR != "42" {
+		t.Fatalf("fetched state for PR %q, want 42", statePR)
+	}
+	got, err := workitem.DecodePRReviewResult(result.Payload)
+	if err != nil {
+		t.Fatalf("DecodePRReviewResult() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, workitem.PRReviewResult{}) {
+		t.Fatalf("closed-PR result = %#v, want empty result", got)
 	}
 }

--- a/internal/arcanum/api_client.go
+++ b/internal/arcanum/api_client.go
@@ -164,13 +164,12 @@ func (c *APIClient) doJSON(ctx context.Context, method string, path string, requ
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf(
-			"Arcanum API request %s %s failed: status %d: %s",
-			method,
-			path,
-			resp.StatusCode,
-			apiErrorBodyExcerpt(raw, resp.StatusCode),
-		)
+		return &APIStatusError{
+			Method:     method,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Body:       apiErrorBodyExcerpt(raw, resp.StatusCode),
+		}
 	}
 
 	if responseBody == nil || len(bytes.TrimSpace(raw)) == 0 {
@@ -180,6 +179,32 @@ func (c *APIClient) doJSON(ctx context.Context, method string, path string, requ
 		return fmt.Errorf("decode Arcanum API response: %w", err)
 	}
 	return nil
+}
+
+// APIStatusError is a non-2xx Arcanum API response. It carries the status code
+// so callers can branch on it (e.g. treat 404 as a deleted review request)
+// instead of matching error strings.
+type APIStatusError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *APIStatusError) Error() string {
+	return fmt.Sprintf(
+		"Arcanum API request %s %s failed: status %d: %s",
+		e.Method,
+		e.Path,
+		e.StatusCode,
+		e.Body,
+	)
+}
+
+// IsAPINotFound reports whether an error is an Arcanum API 404 response.
+func IsAPINotFound(err error) bool {
+	var statusErr *APIStatusError
+	return errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound
 }
 
 func normalizeAPIBaseURL(raw string) (string, error) {

--- a/internal/arcanum/pr_status.go
+++ b/internal/arcanum/pr_status.go
@@ -1,0 +1,68 @@
+package arcanum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// FetchReviewRequestState returns the lifecycle state of an Arcanum review
+// request ("open", "merged", "discarded", ...) using the default production
+// API endpoint. Runner-side gates use it to refuse work on closed PRs.
+func FetchReviewRequestState(ctx context.Context, prID string) (string, error) {
+	client, err := NewAPIClient(APIClientConfig{BaseURL: DefaultAPIBaseURL})
+	if err != nil {
+		return "", err
+	}
+	return FetchReviewRequestStateWithClient(ctx, client, prID)
+}
+
+// FetchReviewRequestStateWithClient is the testable variant of
+// FetchReviewRequestState.
+func FetchReviewRequestStateWithClient(ctx context.Context, client *APIClient, prID string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("Arcanum API client is required")
+	}
+	prID = strings.TrimSpace(prID)
+	if prID == "" {
+		return "", fmt.Errorf("PR ID is required")
+	}
+
+	var raw json.RawMessage
+	if err := client.GetJSON(ctx, reviewRequestStatePath(prID), &raw); err != nil {
+		return "", fmt.Errorf("fetch state for PR %q: %w", prID, err)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return "", fmt.Errorf("parse state for PR %q: %w", prID, err)
+	}
+	body := envelope["data"]
+	if len(body) == 0 {
+		body = raw
+	}
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal(body, &item); err != nil {
+		return "", fmt.Errorf("parse state for PR %q: %w", prID, err)
+	}
+	return firstScalar(item, "state", "status"), nil
+}
+
+// ReviewRequestStateClosed reports whether a review-request state means the PR
+// can no longer accept work (merged or discarded). Unknown or empty states are
+// treated as open so an API contract change degrades to the old behavior
+// instead of silently cancelling live work.
+func ReviewRequestStateClosed(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "merged", "discarded", "closed", "abandoned":
+		return true
+	}
+	return false
+}
+
+func reviewRequestStatePath(prID string) string {
+	query := url.Values{}
+	query.Set("fields", "state")
+	return "/v1/review-requests/" + url.PathEscape(prID) + "?" + query.Encode()
+}

--- a/internal/arcanum/pr_status_test.go
+++ b/internal/arcanum/pr_status_test.go
@@ -1,0 +1,110 @@
+package arcanum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchReviewRequestStateWithClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/api/v1/review-requests/14330209" {
+			t.Fatalf("path = %q, want /api/v1/review-requests/14330209", got)
+		}
+		if fields := r.URL.Query().Get("fields"); fields != "state" {
+			t.Fatalf("fields = %q, want state", fields)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"data":{"id":14330209,"state":"merged"}}`)); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewAPIClient(APIClientConfig{
+		BaseURL:     server.URL + "/api",
+		HTTPClient:  server.Client(),
+		TokenSource: func(context.Context) (string, error) { return "test-token", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	state, err := FetchReviewRequestStateWithClient(context.Background(), client, "14330209")
+	if err != nil {
+		t.Fatalf("FetchReviewRequestStateWithClient() error = %v", err)
+	}
+	if state != "merged" {
+		t.Fatalf("state = %q, want merged", state)
+	}
+}
+
+func TestFetchReviewRequestStateNotFoundIsTyped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"review request not found"}`, http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewAPIClient(APIClientConfig{
+		BaseURL:     server.URL + "/api",
+		HTTPClient:  server.Client(),
+		TokenSource: func(context.Context) (string, error) { return "test-token", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	_, err = FetchReviewRequestStateWithClient(context.Background(), client, "999")
+	if err == nil {
+		t.Fatal("FetchReviewRequestStateWithClient() error = nil, want a 404 error")
+	}
+	if !IsAPINotFound(err) {
+		t.Fatalf("IsAPINotFound(%v) = false, want true", err)
+	}
+}
+
+func TestIsAPINotFoundIgnoresOtherStatuses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewAPIClient(APIClientConfig{
+		BaseURL:     server.URL + "/api",
+		HTTPClient:  server.Client(),
+		TokenSource: func(context.Context) (string, error) { return "test-token", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewAPIClient() error = %v", err)
+	}
+
+	_, err = FetchReviewRequestStateWithClient(context.Background(), client, "999")
+	if err == nil {
+		t.Fatal("FetchReviewRequestStateWithClient() error = nil, want a 500 error")
+	}
+	if IsAPINotFound(err) {
+		t.Fatalf("IsAPINotFound(%v) = true for a 500, want false", err)
+	}
+}
+
+func TestReviewRequestStateClosed(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{"open", false},
+		{"", false},
+		{"draft", false},
+		{"merged", true},
+		{"MERGED", true},
+		{" discarded ", true},
+		{"closed", true},
+		{"abandoned", true},
+	}
+	for _, tc := range cases {
+		if got := ReviewRequestStateClosed(tc.state); got != tc.want {
+			t.Errorf("ReviewRequestStateClosed(%q) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+}

--- a/internal/sources/arcpr/discovery.go
+++ b/internal/sources/arcpr/discovery.go
@@ -82,6 +82,12 @@ type Source struct {
 	// into. It is optional at the Source/discovery layer (wired by cmd) and
 	// discovery must never assume it is present.
 	Queue *workqueue.Store
+	// ReviewRequestState reports a PR's lifecycle state ("open", "merged",
+	// "discarded"). Discovery uses it to verify that a PR which vanished from
+	// the open-PR queries really closed before cancelling its queued work — a
+	// PR can also disappear because the user was merely unassigned. Nil falls
+	// back to the Arcanum API via APIClient.
+	ReviewRequestState func(ctx context.Context, prID string) (string, error)
 	// Author-mode gates default to true (enforced by NewSource). Each gate opts
 	// the author-mode triage into one behavior; clearing one disables only that
 	// behavior while leaving the rest on.
@@ -160,6 +166,9 @@ func (s *Source) Poll(ctx context.Context) ([]workqueue.Submission, error) {
 
 	discovered, err := s.discoverPRs(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.cancelItemsForClosedPRs(ctx, discovered); err != nil {
 		return nil, err
 	}
 	if err := s.reconcileSupersededAuthorImplementItems(ctx, discovered); err != nil {
@@ -276,6 +285,69 @@ func (s *Source) discoverPRs(ctx context.Context) ([]discoveredPR, error) {
 		})
 	}
 	return discovered, nil
+}
+
+// cancelItemsForClosedPRs cancels pending queue items whose PR is no longer
+// open. Discovery only iterates over PRs the open() queries return, so a
+// merged or discarded PR simply vanishes and its leftover items would sit in
+// the queue until a runner claimed them — churning checkout retries against a
+// closed PR or, worse, posting late replies to it (this includes queued
+// resolve-pr-comment follow-ups: resolving threads on a closed review is
+// noise). Absence from discovery alone is not proof of closure, so each
+// absent PR's state is verified against the server; a deleted review request
+// (404) counts as closed. Claimed and running items are never interrupted —
+// the runner-side gates re-check PR state before landing anything.
+func (s *Source) cancelItemsForClosedPRs(ctx context.Context, discovered []discoveredPR) error {
+	if s.Queue == nil {
+		return nil
+	}
+	if s.ReviewRequestState == nil && s.APIClient == nil {
+		// No way to verify server state; leave the queue alone rather than
+		// guess. The cmd wiring always provides an API client.
+		return nil
+	}
+	open := make(map[string]bool, len(discovered))
+	for _, pr := range discovered {
+		open["pr:"+strings.TrimSpace(pr.ID)] = true
+	}
+	pending, err := s.Queue.ListItems(workqueue.ListItemsFilter{
+		Source: s.Name(),
+		State:  "pending",
+	})
+	if err != nil {
+		return fmt.Errorf("list pending arc PR items for closed-PR sweep: %w", err)
+	}
+	itemsByRef := map[string][]workitem.Item{}
+	for _, item := range pending {
+		ref := strings.TrimSpace(item.SourceRef)
+		if !strings.HasPrefix(ref, "pr:") || open[ref] {
+			continue
+		}
+		itemsByRef[ref] = append(itemsByRef[ref], item)
+	}
+	for ref, items := range itemsByRef {
+		prID := strings.TrimPrefix(ref, "pr:")
+		state, err := s.reviewRequestState(ctx, prID)
+		if err != nil && !arcanum.IsAPINotFound(err) {
+			return fmt.Errorf("verify state of undiscovered arc PR %q: %w", prID, err)
+		}
+		if err == nil && !arcanum.ReviewRequestStateClosed(state) {
+			continue
+		}
+		for _, item := range items {
+			if _, err := s.Queue.CancelPendingItem(item.ID); err != nil {
+				return fmt.Errorf("cancel work item %q for closed arc PR %q: %w", item.ID, prID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Source) reviewRequestState(ctx context.Context, prID string) (string, error) {
+	if s.ReviewRequestState != nil {
+		return s.ReviewRequestState(ctx, prID)
+	}
+	return arcanum.FetchReviewRequestStateWithClient(ctx, s.APIClient, prID)
 }
 
 // reconcileSupersededAuthorImplementItems removes pending implementation work

--- a/internal/sources/arcpr/discovery.go
+++ b/internal/sources/arcpr/discovery.go
@@ -329,7 +329,12 @@ func (s *Source) cancelItemsForClosedPRs(ctx context.Context, discovered []disco
 		prID := strings.TrimPrefix(ref, "pr:")
 		state, err := s.reviewRequestState(ctx, prID)
 		if err != nil && !arcanum.IsAPINotFound(err) {
-			return fmt.Errorf("verify state of undiscovered arc PR %q: %w", prID, err)
+			// Best-effort per PR: an unverifiable PR (restricted review,
+			// transient API failure) keeps its items and is retried next
+			// poll. Failing the whole Poll here would let one bad PR exhaust
+			// the sourcehost's consecutive-failure budget and kill discovery;
+			// the runner-side gates still prevent work landing on a closed PR.
+			continue
 		}
 		if err == nil && !arcanum.ReviewRequestStateClosed(state) {
 			continue

--- a/internal/sources/arcpr/discovery_test.go
+++ b/internal/sources/arcpr/discovery_test.go
@@ -990,3 +990,104 @@ func TestSourcePollDefaultsToReviewerModeWhenAuthorNotConfigured(t *testing.T) {
 		t.Fatalf("mode = %q, want reviewer (empty) when Author unset", payload.Mode)
 	}
 }
+
+// A PR that disappeared from the open-PR discovery queries has its queued work
+// cancelled once the server confirms the PR is closed (merged/discarded) or
+// deleted. Still-open PRs that are merely absent from discovery (e.g. the user
+// was unassigned) keep their items, and claimed items are never interrupted.
+func TestSourcePollCancelsPendingItemsForClosedPRs(t *testing.T) {
+	ctx := context.Background()
+	state := openDiscoveryTestState(t)
+	queue, err := workqueue.Open(filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatalf("workqueue.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = queue.Close() })
+
+	enqueue := func(kind workitem.Kind, sourceRef string, key string) string {
+		t.Helper()
+		item, err := queue.Enqueue(workqueue.Submission{
+			Kind:           kind,
+			Source:         "arcpr-adapta",
+			SourceRef:      sourceRef,
+			IdempotencyKey: key,
+			Preset:         "adapta",
+			Payload:        json.RawMessage(`{}`),
+		})
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", key, err)
+		}
+		return item.ID
+	}
+
+	claimedMerged := enqueue(workitem.KindImplement, "pr:100", "closed/claimed")
+	claimed, err := queue.ClaimForSourceRef("runner-live", []string{"adapta"}, "pr:100", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimForSourceRef() error = %v", err)
+	}
+	if claimed == nil || claimed.ID != claimedMerged {
+		t.Fatalf("claimed item = %#v, want %s", claimed, claimedMerged)
+	}
+	mergedImplement := enqueue(workitem.KindImplement, "pr:100", "closed/implement")
+	mergedResolve := enqueue(workitem.KindResolvePRComment, "pr:100", "closed/resolve")
+	openAbsent := enqueue(workitem.KindPRReview, "pr:200", "absent-open/review")
+	deletedImplement := enqueue(workitem.KindImplement, "pr:300", "deleted/implement")
+	discoveredImplement := enqueue(workitem.KindImplement, "pr:42", "discovered/implement")
+
+	stateCalls := map[string]int{}
+	src := &Source{
+		SourceName: "arcpr-adapta",
+		Preset:     "adapta",
+		Author:     "alice",
+		State:      state,
+		Queue:      queue,
+		Lister: PRListerFunc(func(context.Context) ([]arcanum.PRSummary, error) {
+			return []arcanum.PRSummary{{ID: "42", FromID: "active", Author: "alice"}}, nil
+		}),
+		StateFetcher: PRStateFetcherFunc(func(_ context.Context, _ string, prID string) (arcreview.PRRuntimeState, error) {
+			return arcreview.PRRuntimeState{PRID: prID, Details: arcreview.PRDetails{ID: prID}}, nil
+		}),
+		ReviewRequestState: func(_ context.Context, prID string) (string, error) {
+			stateCalls[prID]++
+			switch prID {
+			case "100":
+				return "merged", nil
+			case "200":
+				return "open", nil
+			case "300":
+				return "", &arcanum.APIStatusError{Method: "GET", Path: "/v1/review-requests/300", StatusCode: 404, Body: "not found"}
+			}
+			t.Fatalf("unexpected state fetch for PR %q", prID)
+			return "", nil
+		},
+	}
+	if _, err := src.Poll(ctx); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+
+	wantStates := map[string]string{
+		claimedMerged:       "claimed",
+		mergedImplement:     "cancelled",
+		mergedResolve:       "cancelled",
+		openAbsent:          "pending",
+		deletedImplement:    "cancelled",
+		discoveredImplement: "pending",
+	}
+	for itemID, want := range wantStates {
+		detail, err := queue.GetItem(itemID)
+		if err != nil {
+			t.Fatalf("GetItem(%s): %v", itemID, err)
+		}
+		if detail.Item.State != want {
+			t.Fatalf("item %s state = %q, want %q", itemID, detail.Item.State, want)
+		}
+	}
+	for prID, calls := range stateCalls {
+		if calls != 1 {
+			t.Fatalf("state fetch for PR %q ran %d times, want 1", prID, calls)
+		}
+	}
+	if len(stateCalls) != 3 {
+		t.Fatalf("state fetches = %v, want exactly PRs 100, 200, 300", stateCalls)
+	}
+}

--- a/internal/sources/arcpr/discovery_test.go
+++ b/internal/sources/arcpr/discovery_test.go
@@ -1032,6 +1032,7 @@ func TestSourcePollCancelsPendingItemsForClosedPRs(t *testing.T) {
 	mergedResolve := enqueue(workitem.KindResolvePRComment, "pr:100", "closed/resolve")
 	openAbsent := enqueue(workitem.KindPRReview, "pr:200", "absent-open/review")
 	deletedImplement := enqueue(workitem.KindImplement, "pr:300", "deleted/implement")
+	unverifiableImplement := enqueue(workitem.KindImplement, "pr:400", "unverifiable/implement")
 	discoveredImplement := enqueue(workitem.KindImplement, "pr:42", "discovered/implement")
 
 	stateCalls := map[string]int{}
@@ -1056,6 +1057,11 @@ func TestSourcePollCancelsPendingItemsForClosedPRs(t *testing.T) {
 				return "open", nil
 			case "300":
 				return "", &arcanum.APIStatusError{Method: "GET", Path: "/v1/review-requests/300", StatusCode: 404, Body: "not found"}
+			case "400":
+				// A persistently erroring PR must not fail the poll: one
+				// unverifiable PR would otherwise exhaust the sourcehost's
+				// consecutive-failure budget and kill discovery entirely.
+				return "", &arcanum.APIStatusError{Method: "GET", Path: "/v1/review-requests/400", StatusCode: 403, Body: "forbidden"}
 			}
 			t.Fatalf("unexpected state fetch for PR %q", prID)
 			return "", nil
@@ -1069,9 +1075,10 @@ func TestSourcePollCancelsPendingItemsForClosedPRs(t *testing.T) {
 		claimedMerged:       "claimed",
 		mergedImplement:     "cancelled",
 		mergedResolve:       "cancelled",
-		openAbsent:          "pending",
-		deletedImplement:    "cancelled",
-		discoveredImplement: "pending",
+		openAbsent:            "pending",
+		deletedImplement:      "cancelled",
+		unverifiableImplement: "pending",
+		discoveredImplement:   "pending",
 	}
 	for itemID, want := range wantStates {
 		detail, err := queue.GetItem(itemID)
@@ -1087,7 +1094,7 @@ func TestSourcePollCancelsPendingItemsForClosedPRs(t *testing.T) {
 			t.Fatalf("state fetch for PR %q ran %d times, want 1", prID, calls)
 		}
 	}
-	if len(stateCalls) != 3 {
-		t.Fatalf("state fetches = %v, want exactly PRs 100, 200, 300", stateCalls)
+	if len(stateCalls) != 4 {
+		t.Fatalf("state fetches = %v, want exactly PRs 100, 200, 300, 400", stateCalls)
 	}
 }


### PR DESCRIPTION
## Summary

A PR that merges or is discarded simply vanishes from the open-PR discovery queries, so its queued items were never cancelled — after a supervisor outage the runner would churn checkout retries against closed PRs, post late replies to them, and could even attempt a full implement-and-push cycle on a merged review. Three layers now refuse that work:

- **Discovery sweep** (`internal/sources/arcpr/discovery.go`): pending items whose PR is absent from the open-PR queries are cancelled once the server confirms the PR is closed. A deleted review request (404) counts as closed; a still-open but unassigned PR keeps its items. Claimed/running items are never interrupted.
- **Implement landing-applicability gate** (`cmd/yolo-agent/runner_implement.go`): checks the PR state before fetching comments — a closed PR skips the item terminally ("skipped", no reply posted). Covers items already claimed when the PR closed, which the sweep can't reach.
- **PR-review preflight** (`cmd/yolo-agent/runner_prreview.go`): both reviewer and author mode exit with an empty result for a closed PR before resolving a runtime or preparing a checkout.

Supporting change: Arcanum API errors are now typed (`APIStatusError`) so the sweep branches on 404 with `errors.As` instead of string matching. Unknown/empty states deliberately count as *open* so an API contract change degrades to the old behavior instead of silently cancelling live work.

## Test plan

- [x] New: state fetch + typed 404 (`internal/arcanum/pr_status_test.go`)
- [x] New: discovery sweep — cancels merged + deleted PRs' pending items, keeps open-but-undiscovered PRs and claimed items (`TestSourcePollCancelsPendingItemsForClosedPRs`)
- [x] New: implement gate skips closed PR before comments/checkout (`TestRunnerImplementSkipsWhenPRClosed`)
- [x] New: pr-review exits empty for closed PR before runtime/checkout (`TestRunnerPRReviewSkipsClosedPR`)
- [x] Full suite passes except two pre-existing failures on clean HEAD (`internal/contracts` parity fixtures, `internal/docs` release workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)